### PR TITLE
Add action to build documentation and deploy to github pages

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+# Deploy on pushes to the main branch
+on:
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: "0.4.36"
+    steps:
+      - name: install
+        run: |
+          set -x
+          wget -O - \
+            "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+          | sudo tar xzf - -C /usr/local/bin
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: build
+        run: |
+          mdbook build
+      - name: configure
+        uses: actions/configure-pages@v3
+      - name: upload
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./book/
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
With thanks to @jwnrt for the action (that I've tweaked using the github example mdbook deploy action)