### PR TITLE
Add tracing support to the sonata system

### DIFF
--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -68,6 +68,8 @@ Use the following FuseSoC command to build the simulator binary:
 fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:sonata:system
 ```
 
+*To enable tracing append, `--verilator_options='+define+RVFI'` to the command above.*
+
 ### Running
 
 Running the simulator can be accomplished with the following command, where you can change the `meminit` argument to a different program if you wish:

--- a/dv/verilator/sonata_verilator_lint.vlt
+++ b/dv/verilator/sonata_verilator_lint.vlt
@@ -23,3 +23,15 @@ lint_off -rule IMPERFECTSCH -file "*pulp_riscv_dbg*"
 lint_off -rule DECLFILENAME -file "*pulp_riscv_dbg*"
 lint_off -rule PINMISSING -file "*pulp_riscv_dbg*"
 lint_off -rule UNUSED -file "*ibex_register_file_fpga*"
+
+lint_off -rule UNUSED -file "*ibex_core.sv"
+lint_off -rule UNUSED -file "*cheri_stkz.sv"
+lint_off -rule UNUSED -file "*cheri_tbre.sv"
+lint_off -rule UNUSED -file "*ibex_tracer.sv"
+
+lint_off -rule WIDTH -file "*cheri_stkz.sv"
+lint_off -rule WIDTH -file "*cheri_tbre.sv"
+lint_off -rule WIDTH -file "*ibex_tracer.sv"
+lint_off -rule WIDTH -file "*ibex_core.sv"
+
+lint_off -rule UNDRIVEN -file "*ibexc_top_tracing.sv"

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -492,7 +492,7 @@ module sonata_system #(
 
   assign rst_core_n = rst_sys_ni;
 
-  ibexc_top #(
+  ibexc_top_tracing #(
     .DmHaltAddr      ( DebugStart + dm::HaltAddress[31:0]      ),
     .DmExceptionAddr ( DebugStart + dm::ExceptionAddress[31:0] ),
     .DbgTriggerEn    ( DbgTriggerEn                            ),
@@ -717,7 +717,7 @@ module sonata_system #(
     export "DPI-C" function mhpmcounter_get;
 
     function automatic longint unsigned mhpmcounter_get(int index);
-      return u_top.u_ibex_core.cs_registers_i.mhpmcounter[index];
+      return u_top.u_ibex_top.u_ibex_core.cs_registers_i.mhpmcounter[index];
     endfunction
   `endif
 

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -497,9 +497,9 @@ module sonata_system #(
     .DmExceptionAddr ( DebugStart + dm::ExceptionAddress[31:0] ),
     .DbgTriggerEn    ( DbgTriggerEn                            ),
     .DbgHwBreakNum   ( DbgHwBreakNum                           ),
-    .MHPMCounterNum  ( 10                                      ),
-    .RV32B           ( ibex_pkg::RV32BNone                     )
-  ) u_top (
+    .MHPMCounterNum  ( 13                                      ),
+    .RV32B           ( ibex_pkg::RV32BFull                     )
+  ) u_top_tracing (
     .clk_i (clk_sys_i),
     .rst_ni(rst_core_n),
 
@@ -717,7 +717,7 @@ module sonata_system #(
     export "DPI-C" function mhpmcounter_get;
 
     function automatic longint unsigned mhpmcounter_get(int index);
-      return u_top.u_ibex_top.u_ibex_core.cs_registers_i.mhpmcounter[index];
+      return u_top_tracing.u_ibex_top.u_ibex_core.cs_registers_i.mhpmcounter[index];
     endfunction
   `endif
 

--- a/sonata_system.core
+++ b/sonata_system.core
@@ -7,7 +7,7 @@ description: "Sonata System: putting CHERIoT into the hands of engineers."
 filesets:
   files_rtl_sonata_system:
     depend:
-      - lowrisc:ibex:ibex_top
+      - lowrisc:ibex:ibex_top_tracing
       - pulp:riscv:debug_module
       - lowrisc:ip:xbar_main
       - lowrisc:tlul:adapter_host

--- a/vendor/lowrisc_ibex/ibex_top_tracing.core
+++ b/vendor/lowrisc_ibex/ibex_top_tracing.core
@@ -10,7 +10,7 @@ filesets:
       - lowrisc:ibex:ibex_top
       - lowrisc:ibex:ibex_tracer
     files:
-      - rtl/ibex_top_tracing.sv
+      - rtl/ibexc_top_tracing.sv
     file_type: systemVerilogSource
 
 parameters:
@@ -18,7 +18,6 @@ parameters:
   RVFI:
     datatype: bool
     paramtype: vlogdefine
-    default: true
 
   SYNTHESIS:
     datatype: bool
@@ -111,8 +110,6 @@ targets:
   default: &default_target
     filesets:
       - files_rtl
-    parameters:
-      - RVFI=true
     toplevel: ibex_top_tracing
 
   lint:

--- a/vendor/patches/lowrisc_ibex/0006-Tracing.patch
+++ b/vendor/patches/lowrisc_ibex/0006-Tracing.patch
@@ -1,0 +1,107 @@
+diff --git a/ibex_top_tracing.core b/ibex_top_tracing.core
+index ef4dab5..f544927 100644
+--- a/ibex_top_tracing.core
++++ b/ibex_top_tracing.core
+@@ -10,7 +10,7 @@ filesets:
+       - lowrisc:ibex:ibex_top
+       - lowrisc:ibex:ibex_tracer
+     files:
+-      - rtl/ibex_top_tracing.sv
++      - rtl/ibexc_top_tracing.sv
+     file_type: systemVerilogSource
+ 
+ parameters:
+@@ -18,7 +18,6 @@ parameters:
+   RVFI:
+     datatype: bool
+     paramtype: vlogdefine
+-    default: true
+ 
+   SYNTHESIS:
+     datatype: bool
+@@ -111,8 +110,6 @@ targets:
+   default: &default_target
+     filesets:
+       - files_rtl
+-    parameters:
+-      - RVFI=true
+     toplevel: ibex_top_tracing
+ 
+   lint:
+diff --git a/rtl/ibexc_top_tracing.sv b/rtl/ibexc_top_tracing.sv
+index 7bb5dbc..af5e6b8 100644
+--- a/rtl/ibexc_top_tracing.sv
++++ b/rtl/ibexc_top_tracing.sv
+@@ -10,9 +10,13 @@
+  * Top level module of the ibex RISC-V core with tracing enabled
+  */
+ 
+-module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
++module ibexc_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
+   parameter int unsigned DmHaltAddr       = 32'h1A110800,
+   parameter int unsigned DmExceptionAddr  = 32'h1A110808,
++  parameter bit          DbgTriggerEn     = 1'b1,
++  parameter int unsigned DbgHwBreakNum    = 2,
++  parameter int unsigned MHPMCounterNum   = 0,
++  parameter rv32b_e      RV32B            = RV32BNone,
+   parameter int unsigned HeapBase         = 32'h2001_0000,
+   parameter int unsigned TSMapBase        = 32'h2004_0000, // 4kB default
+   parameter int unsigned TSMapSize        = 1024,          // in words
+@@ -60,7 +64,6 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
+   output logic                         tsmap_cs_o,
+   output logic [15:0]                  tsmap_addr_o,
+   input  logic [31:0]                  tsmap_rdata_i,
+-  input  logic [6:0]                   tsmap_rdata_intg_i,   // not used in ibexc_top
+   input  logic [MMRegDinW-1:0]         mmreg_corein_i,
+   output logic [MMRegDoutW-1:0]        mmreg_coreout_o,
+   output logic                         cheri_fatal_err_o,
+@@ -85,10 +88,13 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
+ 
+   // CPU Control Signals
+   input  fetch_enable_t                fetch_enable_i,
+-  output logic                         core_sleep_o
++  output logic                         core_sleep_o,
++  output logic                         alert_minor_o,
++  output logic                         alert_major_internal_o,
++  output logic                         alert_major_bus_o
+ );
+ 
+-
++`ifdef RVFI
+   logic        rvfi_valid;
+   logic [63:0] rvfi_order;
+   logic [31:0] rvfi_insn;
+@@ -134,16 +140,17 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
+   assign unused_rvfi_ext_nmi = rvfi_ext_nmi;
+   assign unused_rvfi_ext_debug_req = rvfi_ext_debug_req;
+   assign unused_rvfi_ext_mcycle = rvfi_ext_mcycle;
++`endif
+ 
+-  ibex_top #(
++  ibexc_top #(
+     .DmHaltAddr       (DmHaltAddr       ),
+     .DmExceptionAddr  (DmExceptionAddr  ),
+-    .MHPMCounterNum   (13  ),
++    .MHPMCounterNum   (MHPMCounterNum),
+     .MHPMCounterWidth (40),
+-    .DbgTriggerEn     (1'b1),
+-    .DbgHwBreakNum    (4),
++    .DbgTriggerEn     (DbgTriggerEn),
++    .DbgHwBreakNum    (DbgHwBreakNum    ),
+     .RV32E            (1'b0),
+-    .RV32B            (RV32BFull),
++    .RV32B            (RV32B),
+     .WritebackStage   (1'b1),
+     .BranchPredictor  (1'b0),
+     .CHERIoTEn        (1'b1),
+@@ -257,10 +264,6 @@ module ibex_top_tracing import ibex_pkg::*; import cheri_pkg::*; #(
+ 
+ // ibex_tracer relies on the signals from the RISC-V Formal Interface
+ // synthesis translate_off
+-`ifndef RVFI
+-   $fatal("Fatal error: RVFI needs to be defined globally.");
+-`endif
+-
+ `ifdef RVFI
+   ibex_tracer #(
+     .DataWidth        (DataWidth)


### PR DESCRIPTION
Note to use tracing one needs to add ` --verilator_options='+define+RVFI'` to the build command, e.g.

```sh
fusesoc --cores-root=. \
  run --target=sim --tool=verilator --setup \
  --build lowrisc:sonata:system \
  --verilator_options='+define+RVFI'
```