### PR TITLE
Remove UART integrity

### DIFF
--- a/vendor/lowrisc_ip.lock.hjson
+++ b/vendor/lowrisc_ip.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/opentitan
-    rev: fd65a0a7d335214828f51060ac5846df77bbf48f
+    rev: 16bc8ecfaeca634081044eb43ea8975fd2901768
   }
 }

--- a/vendor/lowrisc_ip/ip/uart/rtl/uart.sv
+++ b/vendor/lowrisc_ip/ip/uart/rtl/uart.sv
@@ -39,9 +39,7 @@ module uart import uart_reg_pkg::*; (
     .tl_i,
     .tl_o,
     .reg2hw,
-    .hw2reg,
-    // SEC_CM: BUS.INTEGRITY
-    .intg_err_o ()
+    .hw2reg
   );
 
   uart_core uart_core (

--- a/vendor/lowrisc_ip/ip/uart/rtl/uart_reg_top.sv
+++ b/vendor/lowrisc_ip/ip/uart/rtl/uart_reg_top.sv
@@ -13,10 +13,7 @@ module uart_reg_top (
   output tlul_pkg::tl_d2h_t tl_o,
   // To HW
   output uart_reg_pkg::uart_reg2hw_t reg2hw, // Write
-  input  uart_reg_pkg::uart_hw2reg_t hw2reg, // Read
-
-  // Integrity check errors
-  output logic intg_err_o
+  input  uart_reg_pkg::uart_hw2reg_t hw2reg  // Read
 );
 
   import uart_reg_pkg::* ;
@@ -41,40 +38,6 @@ module uart_reg_top (
 
   tlul_pkg::tl_h2d_t tl_reg_h2d;
   tlul_pkg::tl_d2h_t tl_reg_d2h;
-
-
-  // incoming payload check
-  logic intg_err;
-  tlul_cmd_intg_chk u_chk (
-    .tl_i(tl_i),
-    .err_o(intg_err)
-  );
-
-  // also check for spurious write enables
-  logic reg_we_err;
-  logic [12:0] reg_we_check;
-  prim_reg_we_check #(
-    .OneHotWidth(13)
-  ) u_prim_reg_we_check (
-    .clk_i(clk_i),
-    .rst_ni(rst_ni),
-    .oh_i  (reg_we_check),
-    .en_i  (reg_we && !addrmiss),
-    .err_o (reg_we_err)
-  );
-
-  logic err_q;
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      err_q <= '0;
-    end else if (intg_err || reg_we_err) begin
-      err_q <= 1'b1;
-    end
-  end
-
-  // integrity error output is permanent and should be used for alert generation
-  // register errors are transactional
-  assign intg_err_o = err_q | intg_err | reg_we_err;
 
   // outgoing integrity generation
   tlul_pkg::tl_d2h_t tl_o_pre;
@@ -116,7 +79,7 @@ module uart_reg_top (
   // cdc oversampling signals
 
   assign reg_rdata = reg_rdata_next ;
-  assign reg_error = addrmiss | wr_err | intg_err;
+  assign reg_error = addrmiss | wr_err;
 
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
@@ -1620,24 +1583,6 @@ module uart_reg_top (
   assign timeout_ctrl_val_wd = reg_wdata[23:0];
 
   assign timeout_ctrl_en_wd = reg_wdata[31];
-
-  // Assign write-enables to checker logic vector.
-  always_comb begin
-    reg_we_check = '0;
-    reg_we_check[0] = intr_state_we;
-    reg_we_check[1] = intr_enable_we;
-    reg_we_check[2] = intr_test_we;
-    reg_we_check[3] = alert_test_we;
-    reg_we_check[4] = ctrl_we;
-    reg_we_check[5] = 1'b0;
-    reg_we_check[6] = 1'b0;
-    reg_we_check[7] = wdata_we;
-    reg_we_check[8] = fifo_ctrl_we;
-    reg_we_check[9] = 1'b0;
-    reg_we_check[10] = ovrd_we;
-    reg_we_check[11] = 1'b0;
-    reg_we_check[12] = timeout_ctrl_we;
-  end
 
   // Read data return
   always_comb begin

--- a/vendor/lowrisc_ip/util/reggen/ip_block.py
+++ b/vendor/lowrisc_ip/util/reggen/ip_block.py
@@ -56,7 +56,11 @@ KNOWN_CIP_IDS = {
     32: 'alert_handler',
     33: 'rv_plic',
     34: 'ast',
-    35: 'sensor_ctrl'
+    35: 'sensor_ctrl',
+    36: 'dma',
+    37: 'mbx',
+    38: 'soc_proxy',
+    39: 'keymgr_dpe'
 }
 
 REQUIRED_ALIAS_FIELDS = {

--- a/vendor/patches/lowrisc_ip/uart/0002-Remove-Integrity-Check.patch
+++ b/vendor/patches/lowrisc_ip/uart/0002-Remove-Integrity-Check.patch
@@ -1,0 +1,106 @@
+diff --git a/rtl/uart.sv b/rtl/uart.sv
+index 89c51c1..4c7b8c1 100644
+--- a/rtl/uart.sv
++++ b/rtl/uart.sv
+@@ -39,9 +39,7 @@ module uart import uart_reg_pkg::*; (
+     .tl_i,
+     .tl_o,
+     .reg2hw,
+-    .hw2reg,
+-    // SEC_CM: BUS.INTEGRITY
+-    .intg_err_o ()
++    .hw2reg
+   );
+
+   uart_core uart_core (
+diff --git a/rtl/uart_reg_top.sv b/rtl/uart_reg_top.sv
+index 57114e3..1a83e5a 100644
+--- a/rtl/uart_reg_top.sv
++++ b/rtl/uart_reg_top.sv
+@@ -13,10 +13,7 @@ module uart_reg_top (
+   output tlul_pkg::tl_d2h_t tl_o,
+   // To HW
+   output uart_reg_pkg::uart_reg2hw_t reg2hw, // Write
+-  input  uart_reg_pkg::uart_hw2reg_t hw2reg, // Read
+-
+-  // Integrity check errors
+-  output logic intg_err_o
++  input  uart_reg_pkg::uart_hw2reg_t hw2reg  // Read
+ );
+ 
+   import uart_reg_pkg::* ;
+@@ -42,40 +39,6 @@ module uart_reg_top (
+   tlul_pkg::tl_h2d_t tl_reg_h2d;
+   tlul_pkg::tl_d2h_t tl_reg_d2h;
+ 
+-
+-  // incoming payload check
+-  logic intg_err;
+-  tlul_cmd_intg_chk u_chk (
+-    .tl_i(tl_i),
+-    .err_o(intg_err)
+-  );
+-
+-  // also check for spurious write enables
+-  logic reg_we_err;
+-  logic [12:0] reg_we_check;
+-  prim_reg_we_check #(
+-    .OneHotWidth(13)
+-  ) u_prim_reg_we_check (
+-    .clk_i(clk_i),
+-    .rst_ni(rst_ni),
+-    .oh_i  (reg_we_check),
+-    .en_i  (reg_we && !addrmiss),
+-    .err_o (reg_we_err)
+-  );
+-
+-  logic err_q;
+-  always_ff @(posedge clk_i or negedge rst_ni) begin
+-    if (!rst_ni) begin
+-      err_q <= '0;
+-    end else if (intg_err || reg_we_err) begin
+-      err_q <= 1'b1;
+-    end
+-  end
+-
+-  // integrity error output is permanent and should be used for alert generation
+-  // register errors are transactional
+-  assign intg_err_o = err_q | intg_err | reg_we_err;
+-
+   // outgoing integrity generation
+   tlul_pkg::tl_d2h_t tl_o_pre;
+   tlul_rsp_intg_gen #(
+@@ -116,7 +79,7 @@ module uart_reg_top (
+   // cdc oversampling signals
+ 
+   assign reg_rdata = reg_rdata_next ;
+-  assign reg_error = addrmiss | wr_err | intg_err;
++  assign reg_error = addrmiss | wr_err;
+ 
+   // Define SW related signals
+   // Format: <reg>_<field>_{wd|we|qs}
+@@ -1621,24 +1584,6 @@ module uart_reg_top (
+ 
+   assign timeout_ctrl_en_wd = reg_wdata[31];
+ 
+-  // Assign write-enables to checker logic vector.
+-  always_comb begin
+-    reg_we_check = '0;
+-    reg_we_check[0] = intr_state_we;
+-    reg_we_check[1] = intr_enable_we;
+-    reg_we_check[2] = intr_test_we;
+-    reg_we_check[3] = alert_test_we;
+-    reg_we_check[4] = ctrl_we;
+-    reg_we_check[5] = 1'b0;
+-    reg_we_check[6] = 1'b0;
+-    reg_we_check[7] = wdata_we;
+-    reg_we_check[8] = fifo_ctrl_we;
+-    reg_we_check[9] = 1'b0;
+-    reg_we_check[10] = ovrd_we;
+-    reg_we_check[11] = 1'b0;
+-    reg_we_check[12] = timeout_ctrl_we;
+-  end
+-
+   // Read data return
+   always_comb begin
+     reg_rdata_next = '0;


### PR DESCRIPTION
This was accidentally added back in when I upgraded the primitives. This integrity check is causing bus errors.