### PR TITLE
Introduce CHERI enable/disable switch

### DIFF
--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -7,6 +7,7 @@ module top_verilator (input logic clk_i, rst_ni);
 
   localparam ClockFrequency = 25_000_000;
   localparam BaudRate       = 115_200;
+  localparam EnableCHERI    = 1'b1;
 
   logic uart_sys_rx, uart_sys_tx;
 
@@ -43,6 +44,7 @@ module top_verilator (input logic clk_i, rst_ni);
     .spi_tx_o ( ),
     .spi_sck_o( ),
 
+    .cheri_en_i (EnableCHERI),
     // CHERI output
     .cheri_err_o(),
     .cheri_en_o (),

--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -75,6 +75,20 @@ module top_sonata (
   assign scl1 = scl1_oe ? scl1_o : 1'bZ;
   assign sda1 = sda1_oe ? sda1_o : 1'bZ;
 
+  // DIP switches are OFF by default and employ a pull up, which means CHERI shall enabled by
+  // default; sample this once when leaving reset as a development aid during bring up.
+  logic enable_cheri;
+  logic cheri_decided;
+  always_ff @(posedge clk_sys or negedge rst_sys_n) begin
+    if (!rst_sys_n) begin
+      cheri_decided <= 1'b0;
+      enable_cheri  <= 1'b1;
+    end else if (!cheri_decided) begin
+      enable_cheri  <= usrSw[7];
+      cheri_decided <= 1'b1;
+    end
+  end
+
   sonata_system #(
     .GpiWidth     ( 13           ),
     .GpoWidth     ( 12           ),
@@ -98,6 +112,7 @@ module top_sonata (
     .spi_tx_o       (lcd_copi),
     .spi_sck_o      (lcd_clk),
 
+    .cheri_en_i     (enable_cheri),
     .cheri_err_o    (cheriErr),
     .cheri_en_o     (cheri_en),
 

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -37,6 +37,9 @@ module sonata_system #(
   input  logic td_i,    // JTAG test data input pad
   output logic td_o,    // JTAG test data output pad
 
+  // TODO: Development assistance.
+  input  logic                     cheri_en_i,
+
   output logic [CheriErrWidth-1:0] cheri_err_o,
   output logic                     cheri_en_o,
 
@@ -505,7 +508,7 @@ module sonata_system #(
 
   logic cheri_en;
 
-  assign cheri_en = 1'b1;
+  assign cheri_en   = cheri_en_i;
   assign cheri_en_o = cheri_en;
   assign rst_core_n = rst_sys_ni & ~ndmreset_req & ~host_req[DbgHost];
 


### PR DESCRIPTION
CHERI shall be enabled by default. To disable CHERI functionality experimentally, eg. to run the legacy code base, set DIP switch 8 to ON before bringing the system out of reset.
If wishing to toggle a FPGA image with downloaded code between CHERI and non-CHERI, the Reset switch on the Sonata board may be used, provided that the software has not destructively modified RAM contents eg. code.