### PR TITLE
uartdpi: Ignore write failures

### DIFF
--- a/vendor/lowrisc_ip.vendor.hjson
+++ b/vendor/lowrisc_ip.vendor.hjson
@@ -25,6 +25,6 @@
         {from: "hw/top_earlgrey/top_pkg.core",   to: "ip/top_pkg/top_pkg.core"},
         {from: "hw/top_earlgrey/rtl/top_pkg.sv", to: "ip/top_pkg/rtl/top_pkg.sv"},
 
-        {from: "hw/dv/dpi/uartdpi",    to: "dv/dpi/uartdpi"},
+        {from: "hw/dv/dpi/uartdpi",    to: "dv/dpi/uartdpi", patch_dir: "uartdpi"},
     ]
 }

--- a/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.c
+++ b/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.c
@@ -131,10 +131,16 @@ void uartdpi_write(void *ctx_void, char c) {
   }
 
   rv = write(ctx->host, &c, 1);
-  assert(rv == 1 && "Write to pseudo-terminal failed.");
+
+  if (rv != 1) {
+    fprintf(stderr, "UART: Write to pseudo-terminal failed: %s\n", strerror(errno));
+  }
 
   if (ctx->log_file) {
     rv = fwrite(&c, sizeof(char), 1, ctx->log_file);
-    assert(rv == 1 && "Write to log file failed.");
+
+    if (rv != 1) {
+      fprintf(stderr, "UART: Write to log file failed: %s\n", strerror(errno));
+    }
   }
 }

--- a/vendor/patches/lowrisc_ip/uartdpi/0001-Ignore-Write-Errors.patch
+++ b/vendor/patches/lowrisc_ip/uartdpi/0001-Ignore-Write-Errors.patch
@@ -1,0 +1,23 @@
+diff --git a/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.c b/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.c
+index 6e8fa3f..bb3d1a5 100644
+--- a/uartdpi.c
++++ b/uartdpi.c
+@@ -131,10 +131,16 @@ void uartdpi_write(void *ctx_void, char c) {
+   }
+ 
+   rv = write(ctx->host, &c, 1);
+-  assert(rv == 1 && "Write to pseudo-terminal failed.");
++
++  if (rv != 1) {
++    fprintf(stderr, "UART: Write to pseudo-terminal failed: %s\n", strerror(errno));
++  }
+ 
+   if (ctx->log_file) {
+     rv = fwrite(&c, sizeof(char), 1, ctx->log_file);
+-    assert(rv == 1 && "Write to log file failed.");
++
++    if (rv != 1) {
++      fprintf(stderr, "UART: Write to log file failed: %s\n", strerror(errno));
++    }
+   }
+ }


### PR DESCRIPTION
Currently if there is failure to write to the TTY or file, an assert fails and the simulation core dumps.

This patch changes that to log the error that was observed and continue the simulation.