### PR TITLE
Fix rv_timer register offsets

### DIFF
--- a/rtl/system/rv_timer.sv
+++ b/rtl/system/rv_timer.sv
@@ -32,10 +32,10 @@ module rv_timer #(
   // Upper bits of address are decoded into timer_req_i
   localparam int unsigned ADDR_OFFSET = 16; // 64 KiB
   // Register map
-  localparam bit [ADDR_OFFSET-1:0] MTIME_LOW = 'h4000;
-  localparam bit [ADDR_OFFSET-1:0] MTIME_HIGH = MTIME_LOW + 4;
-  localparam bit [ADDR_OFFSET-1:0] MTIMECMP_LOW = 'hBFF8;
+  localparam bit [ADDR_OFFSET-1:0] MTIMECMP_LOW = 'h4000;
   localparam bit [ADDR_OFFSET-1:0] MTIMECMP_HIGH = MTIMECMP_LOW + 4;
+  localparam bit [ADDR_OFFSET-1:0] MTIME_LOW = 'hBFF8;
+  localparam bit [ADDR_OFFSET-1:0] MTIME_HIGH = MTIME_LOW + 4;
 
   logic                 timer_we;
   logic                 mtime_we, mtimeh_we;

--- a/sw/legacy/common/timer.h
+++ b/sw/legacy/common/timer.h
@@ -7,10 +7,10 @@
 
 #include "stdint.h"
 
-#define TIMER_MTIME_REG     0x4000
-#define TIMER_MTIMEH_REG    0x4004
-#define TIMER_MTIMECMP_REG  0xbff8
-#define TIMER_MTIMECMPH_REG 0xbffc
+#define TIMER_MTIMECMP_REG  0x4000
+#define TIMER_MTIMECMPH_REG 0x4004
+#define TIMER_MTIME_REG     0xbff8
+#define TIMER_MTIMEH_REG    0xbffc
 
 void timer_init();
 uint64_t timer_read();

--- a/sw/legacy/timer_test/timer_test.cc
+++ b/sw/legacy/timer_test/timer_test.cc
@@ -34,10 +34,10 @@ class SonataTimer
   uint32_t size_;
 
   // Offsets of registers within address range.
-  static constexpr uint32_t mtime  = 0x4000u / 4;
-  static constexpr uint32_t mtimeh = mtime + 1;
-  static constexpr uint32_t mtimecmp  = 0xbff8u / 4;
+  static constexpr uint32_t mtimecmp  = 0x4000u / 4;
   static constexpr uint32_t mtimecmph = mtimecmp + 1;
+  static constexpr uint32_t mtime  = 0xbff8u / 4;
+  static constexpr uint32_t mtimeh = mtime + 1;
 
 public:
 


### PR DESCRIPTION
Transpose mtime and mtimecmp registers in rv_timer implementation to match CLINT specification.
Change legacy software accordingly.