### PR TITLE
SRAM tag fix

### DIFF
--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -789,7 +789,7 @@ module sonata_system #(
   i2c u_i2c0(
       .clk_i                    (clk_sys_i),
       .rst_ni                   (rst_sys_ni),
-      .ram_cfg_i                ('b0),
+      .ram_cfg_i                (10'b0),
 
       // Bus Interface
       .tl_i                     (tl_i2c0_h2d),
@@ -824,7 +824,7 @@ module sonata_system #(
   i2c u_i2c1(
       .clk_i                    (clk_sys_i),
       .rst_ni                   (rst_sys_ni),
-      .ram_cfg_i                ('b0),
+      .ram_cfg_i                (10'b0),
 
       // Bus Interface
       .tl_i                     (tl_i2c1_h2d),
@@ -942,7 +942,7 @@ module sonata_system #(
     .usb_ref_val_o          (),
     .usb_ref_pulse_o        (),
 
-    .ram_cfg_i              ('b0),
+    .ram_cfg_i              (10'b0),
 
     // Interrupts not required
     .intr_pkt_received_o    (),

--- a/rtl/system/sram.sv
+++ b/rtl/system/sram.sv
@@ -147,7 +147,7 @@ module sram #(
     .Depth ( RamDepth )
   ) u_cap_ram (
     .clk_a_i   (clk_i),
-    .clk_b_i   (rst_ni),
+    .clk_b_i   (clk_i),
     .cfg_i     ('0),
     .a_req_i   (mem_a_req),
     .a_write_i (&mem_a_we),


### PR DESCRIPTION
Originally the clock on the B port of the capability tags were connected to the reset instead of the clock. This PR fixes that. It also fixes some width warnings that Vivado produces.