### PR TITLE
Shrink tag RAM

### DIFF
--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -323,7 +323,7 @@ module sonata_system #(
   wire dbg_release_core = &dbg_release_cnt;
   always_ff @(posedge clk_sys_i or negedge rst_sys_ni) begin
     if (!rst_sys_ni) begin
-      dbg_release_cnt  <= '0;
+      dbg_release_cnt  <= {21{1'b1}};
     end else if (host_req[DbgHost] | ~dbg_release_core) begin
       dbg_release_cnt  <= host_req[DbgHost] ? '0 : (dbg_release_cnt + 1);
     end

--- a/rtl/system/sram.sv
+++ b/rtl/system/sram.sv
@@ -32,7 +32,7 @@ module sram #(
   //
   // For all non-capability stores the tag bit will be cleared, marking those
   // 64 bits as not containing a valid capability.
-  localparam int unsigned TOff = SingleTagPerCap ? (3 - AOff) : 0;
+  localparam int unsigned TOff = (SingleTagPerCap == 1) ? (3 - AOff) : 0;
 
   // Bit offset of word address.
   localparam int unsigned AOff = $clog2(DataWidth / 8);

--- a/sw/cheri/tests/CMakeLists.txt
+++ b/sw/cheri/tests/CMakeLists.txt
@@ -20,3 +20,15 @@ foreach(TEST ${TESTS})
     VERBATIM
   )
 endforeach()
+
+set(NAME tag_test)
+
+add_executable(${NAME} "tag_test.S")
+target_include_directories(${NAME} PRIVATE "${CHERIOT_RTOS_SDK}/include")
+
+add_custom_command(
+  TARGET ${NAME} POST_BUILD
+  COMMAND ${CMAKE_OBJCOPY} -O binary "$<TARGET_FILE:${NAME}>" "$<TARGET_FILE:${NAME}>.bin"
+  COMMAND srec_cat "$<TARGET_FILE:${NAME}>.bin" -binary -offset 0x0000 -byte-swap 4 -o "$<TARGET_FILE:${NAME}>.vmem" -vmem
+  VERBATIM
+)

--- a/sw/cheri/tests/tag_test.S
+++ b/sw/cheri/tests/tag_test.S
@@ -1,0 +1,111 @@
+.include "assembly-helpers.s"
+
+.section .text.start, "ax", @progbits
+  .zero 0x80
+  .globl start
+  .p2align 2
+  .type start,@function
+start:
+  // The memory root for storing and loading.
+  cspecialr ca0, mtdc
+  // The execution root.
+  auipcc ca1, 0
+  // The sealing root.
+  cspecialr ca2, mscratchc
+
+.section .text
+  // Get capability to storage in ct0
+  la_abs t0, storage
+  srli t0, t0, 3 // Make sure it is 64-bit aligned
+  slli t0, t0, 3
+  csetaddr ct0, ca0, t0
+  // Check that tags start out as 0
+  clc ct1,  0(ct0)
+  cgettag t2, ct1
+  bnez t2, fail
+  clc ct1,  8(ct0)
+  cgettag t2, ct1
+  bnez t2, fail
+  clc ct1, 16(ct0)
+  cgettag t2, ct1
+  bnez t2, fail
+  // Store valid capabilities
+  csc ct0,  0(ct0)
+  csc ct0,  8(ct0)
+  csc ct0, 16(ct0)
+  // Check that tags are all valid
+  clc ct1,  0(ct0)
+  cgettag t2, ct1
+  beqz t2, fail
+  clc ct1,  8(ct0)
+  cgettag t2, ct1
+  beqz t2, fail
+  clc ct1, 16(ct0)
+  cgettag t2, ct1
+  beqz t2, fail
+  // Invalidate second capability with write to top word
+  csw zero, 8(ct0)
+  // Check tags are 1,0,1
+  clc ct1,  0(ct0)
+  cgettag t2, ct1
+  beqz t2, fail
+  clc ct1,  8(ct0)
+  cgettag t2, ct1
+  bnez t2, fail
+  clc ct1, 16(ct0)
+  cgettag t2, ct1
+  beqz t2, fail
+  // Write back valid capability
+  csc ct0,  8(ct0)
+  // Invalidate second capability with write to middle byte
+  csb zero,13(ct0)
+  // Check that tags are 1,0,1
+  clc ct1,  0(ct0)
+  cgettag t2, ct1
+  beqz t2, fail
+  clc ct1,  8(ct0)
+  cgettag t2, ct1
+  bnez t2, fail
+  clc ct1, 16(ct0)
+  cgettag t2, ct1
+  beqz t2, fail
+  // Invalidate other two capabilities
+  csh zero, 4(ct0)
+  csw zero,20(ct0)
+  // Check that tags are all invalid
+  clc ct1,  0(ct0)
+  cgettag t2, ct1
+  bnez t2, fail
+  clc ct1,  8(ct0)
+  cgettag t2, ct1
+  bnez t2, fail
+  clc ct1, 16(ct0)
+  cgettag t2, ct1
+  bnez t2, fail
+
+success:
+  j success
+
+  nop // In case of misalignment
+  nop
+  nop
+storage:
+  // First capability
+  nop
+  nop
+  nop
+  nop
+  // Second capability
+  nop
+  nop
+  nop
+  nop
+  // Third capability
+  nop
+  nop
+  nop
+  nop
+
+// If we get here we know something went wrong.
+fail:
+  j fail


### PR DESCRIPTION
There is a single capability tag bit per 64 bits of data. With two bits per 64 bits a write to one half of the 64-bit capability will not invalidate the capability tag associated with the other half.