### PR TITLE
256KiB RAM, 30MHz system clock on A50T

### DIFF
--- a/data/xbar_main.hjson
+++ b/data/xbar_main.hjson
@@ -36,7 +36,7 @@
       xbar:  false,
       addr_range: [{
         base_addr: "0x00100000",
-        size_byte: "0x00020000",
+        size_byte: "0x00040000",
       }],
     },
     { name:  "rev_tag", // Revocation tag memory

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -5,7 +5,7 @@
 // This is the top level that connects the system to the virtual devices.
 module top_verilator (input logic clk_i, rst_ni);
 
-  localparam ClockFrequency = 25_000_000;
+  localparam ClockFrequency = 30_000_000;
   localparam BaudRate       = 115_200;
   localparam EnableCHERI    = 1'b1;
 

--- a/rtl/bus/tl_main_pkg.sv
+++ b/rtl/bus/tl_main_pkg.sv
@@ -20,7 +20,7 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_SPACE_USBDEV    = 32'h 80400000;
   localparam logic [31:0] ADDR_SPACE_RV_PLIC   = 32'h 88000000;
 
-  localparam logic [31:0] ADDR_MASK_SRAM      = 32'h 0001ffff;
+  localparam logic [31:0] ADDR_MASK_SRAM      = 32'h 0003ffff;
   localparam logic [31:0] ADDR_MASK_REV_TAG   = 32'h 00003fff;
   localparam logic [31:0] ADDR_MASK_GPIO      = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_PWM       = 32'h 00000fff;

--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -77,7 +77,7 @@ module top_sonata (
   output logic appspi_cs  // Chip select negated
 );
   // System clock frequency.
-  parameter int SysClkFreq = 25_000_000;
+  parameter int SysClkFreq = 30_000_000;
 
   parameter SRAMInitFile = "";
 

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -104,6 +104,11 @@ module sonata_system #(
   localparam int unsigned RegAddrWidth  = 8;
   localparam int unsigned TRegAddrWidth = 16;  // Timer uses more address bits.
 
+  // The number of data bits controlled by each mask bit; since the CPU requires
+  // only byte level access, explicitly grouping the data bits makes the inferred
+  // BRAM implementations in FPGA much more efficient.
+  localparam int unsigned DataBitsPerMask = BusDataWidth / BusByteEnable;
+
   // Debug functionality is disabled.
   localparam int unsigned DbgHwBreakNum = 0;
   localparam bit          DbgTriggerEn  = 1'b0;
@@ -517,8 +522,10 @@ module sonata_system #(
   );
 
   sram #(
-    .AddrWidth ( SRAMAddrWidth ),
-    .InitFile  ( SRAMInitFile  )
+    .AddrWidth       ( SRAMAddrWidth   ),
+    .DataWidth       ( BusDataWidth    ),
+    .DataBitsPerMask ( DataBitsPerMask ),
+    .InitFile        ( SRAMInitFile    )
   ) u_sram_top (
     .clk_i  (clk_sys_i),
     .rst_ni (rst_sys_ni),
@@ -669,8 +676,9 @@ module sonata_system #(
   assign device_addr[RevTags][BusAddrWidth-1:RevTagAddrWidth] = '0;
 
   prim_ram_2p #(
-    .Width ( BusDataWidth ),
-    .Depth ( RevTagDepth  )
+    .Depth           ( RevTagDepth     ),
+    .Width           ( BusDataWidth    ),
+    .DataBitsPerMask ( DataBitsPerMask )
   ) u_revocation_ram (
     .clk_a_i   (clk_sys_i),
     .clk_b_i   (rst_sys_ni),

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -94,7 +94,7 @@ module sonata_system #(
   // Signals, types and parameters for system. //
   ///////////////////////////////////////////////
 
-  localparam int unsigned MemSize       = 128 * 1024; // 128 KiB
+  localparam int unsigned MemSize       = 256 * 1024; // 256 KiB
   localparam int unsigned SRAMAddrWidth = $clog2(MemSize);
   localparam int unsigned DebugStart    = 32'h1a110000;
   localparam int unsigned PwmCtrSize    = 8;

--- a/rtl/system/sram.sv
+++ b/rtl/system/sram.sv
@@ -5,6 +5,10 @@
 module sram #(
   // (Byte-addressable) address width of the SRAM.
   parameter int unsigned AddrWidth = 17,
+  // Data width of the SRAM.
+  parameter int unsigned DataWidth = 32,
+  // Grouping of data bits into sub-words.
+  parameter int unsigned DataBitsPerMask = 8,
   parameter InitFile               = ""
 ) (
     input  logic clk_i,
@@ -17,33 +21,33 @@ module sram #(
     output tlul_pkg::tl_d2h_t tl_b_o
   );
 
-  localparam int unsigned BusAddrWidth  = 32;
-  localparam int unsigned BusByteEnable = 4;
-  localparam int unsigned BusDataWidth  = 32;
+  // Bit offset of word address.
+  localparam int unsigned AOff = $clog2(DataWidth / 8);
+  // Number of address bits to select a word from the SRAM.
+  localparam int unsigned SramAw = AddrWidth - AOff;
 
   logic                     mem_a_req;
-  logic [BusAddrWidth-1:0]  mem_a_addr;
+  logic [AddrWidth-1:AOff]  mem_a_addr;
   logic                     mem_a_we;
-  logic [BusByteEnable-1:0] mem_a_be;
-  logic [BusDataWidth-1:0]  mem_a_wdata;
+  logic [DataWidth-1:0]     mem_a_wmask;
+
+  logic [DataWidth-1:0]     mem_a_wdata;
   logic                     mem_a_wcap;
   logic                     mem_a_rvalid;
-  logic [BusDataWidth-1:0]  mem_a_rdata;
+  logic [DataWidth-1:0]     mem_a_rdata;
   logic                     mem_a_rcap;
 
   logic                    mem_b_req;
+  logic                    mem_b_we;
   logic                    mem_b_rvalid;
-  logic [BusAddrWidth-1:0] mem_b_addr;
-  logic [BusDataWidth-1:0] mem_b_rdata;
+  logic [AddrWidth-1:AOff] mem_b_addr;
+  logic [DataWidth-1:0]    mem_b_rdata;
   logic                    unused_mem_b_rcap;
 
   // TL-UL device adapters
-
-  logic [BusDataWidth-1:0] sram_data_bit_enable;
-
   tlul_adapter_sram #(
-    .SramAw           ( AddrWidth - 2 ),
-    .EnableRspIntgGen ( 1             )
+    .SramAw           ( SramAw ),
+    .EnableRspIntgGen ( 1      )
   ) sram_a_device_adapter (
     .clk_i,
     .rst_ni,
@@ -60,10 +64,10 @@ module sram #(
     .req_type_o  (),
     .gnt_i       (mem_a_req),
     .we_o        (mem_a_we),
-    .addr_o      (mem_a_addr[AddrWidth-1:2]),
+    .addr_o      (mem_a_addr),
     .wdata_o     (mem_a_wdata),
     .wdata_cap_o (mem_a_wcap),
-    .wmask_o     (sram_data_bit_enable),
+    .wmask_o     (mem_a_wmask),
     .intg_error_o(),
     .rdata_i     (mem_a_rdata),
     .rdata_cap_i (mem_a_rcap),
@@ -71,19 +75,9 @@ module sram #(
     .rerror_i    (2'b00)
   );
 
-  // Tie off upper and lower bits of address.
-  assign mem_a_addr[BusAddrWidth-1:AddrWidth] = '0;
-  assign mem_a_addr[1:0] = '0;
-
-  // Translate bit-level enable signals to Byte-level.
-  assign mem_a_be[0] = |sram_data_bit_enable[ 7: 0];
-  assign mem_a_be[1] = |sram_data_bit_enable[15: 8];
-  assign mem_a_be[2] = |sram_data_bit_enable[23:16];
-  assign mem_a_be[3] = |sram_data_bit_enable[31:24];
-
   tlul_adapter_sram #(
-    .SramAw           ( AddrWidth - 2 ),
-    .EnableRspIntgGen ( 1             )
+    .SramAw           ( SramAw ),
+    .EnableRspIntgGen ( 1      )
   ) sram_b_device_adapter (
     .clk_i,
     .rst_ni,
@@ -99,8 +93,8 @@ module sram #(
     .req_o(mem_b_req),
     .req_type_o(),
     .gnt_i(mem_b_req),
-    .we_o(),
-    .addr_o(mem_b_addr[AddrWidth-1:2]),
+    .we_o(mem_b_we),
+    .addr_o(mem_b_addr),
     .wdata_o(),
     .wdata_cap_o(),
     .wmask_o(),
@@ -111,37 +105,39 @@ module sram #(
     .rerror_i(2'b00)
   );
 
-  assign mem_b_addr[BusAddrWidth-1:AddrWidth] = '0;
-  assign mem_b_addr[1:0] = '0;
+  // Number of words in data memory.
+  localparam int unsigned RamDepth = 2 ** SramAw;
 
   // Instantiate RAM blocks
 
-  localparam int RamDepth = 2 ** (AddrWidth - 2);
-
-  ram_2p #(
-    .Depth       ( RamDepth ),
-    .MemInitFile ( InitFile )
+  // Data memory
+  prim_ram_2p #(
+    .Width           ( DataWidth       ),
+    .DataBitsPerMask ( DataBitsPerMask ),
+    .Depth           ( RamDepth        ),
+    .MemInitFile     ( InitFile        )
   ) u_ram (
-    .clk_i,
-    .rst_ni,
+    .clk_a_i   (clk_i),
+    .clk_b_i   (clk_i),
 
     .a_req_i   (mem_a_req),
-    .a_we_i    (mem_a_we),
-    .a_be_i    (mem_a_be),
+    .a_write_i (mem_a_we),
     .a_addr_i  (mem_a_addr),
     .a_wdata_i (mem_a_wdata),
-    .a_rvalid_o(mem_a_rvalid),
+    .a_wmask_i (mem_a_wmask),
     .a_rdata_o (mem_a_rdata),
 
     .b_req_i   (mem_b_req),
-    .b_we_i    (1'b0),
-    .b_be_i    (BusByteEnable'(0)),
+    .b_write_i (1'b0),
     .b_addr_i  (mem_b_addr),
-    .b_wdata_i (BusDataWidth'(0)),
-    .b_rvalid_o(mem_b_rvalid),
-    .b_rdata_o (mem_b_rdata)
+    .b_wdata_i (DataWidth'(0)),
+    .b_wmask_i (DataWidth'(0)),
+    .b_rdata_o (mem_b_rdata),
+
+    .cfg_i     ('0)
   );
 
+  // Tag memory
   prim_ram_2p #(
     .Width ( 1        ),
     .Depth ( RamDepth )
@@ -151,16 +147,27 @@ module sram #(
     .cfg_i     ('0),
     .a_req_i   (mem_a_req),
     .a_write_i (&mem_a_we),
-    .a_addr_i  (mem_a_addr[AddrWidth-1:2]),
+    .a_addr_i  (mem_a_addr[AddrWidth-1:AOff]),
     .a_wdata_i (mem_a_wcap),
     .a_wmask_i (&mem_a_we),
     .a_rdata_o (mem_a_rcap),
     .b_req_i   (mem_b_req),
     .b_write_i (1'b0),
     .b_wmask_i (1'b0),
-    .b_addr_i  (mem_b_addr[AddrWidth-1:2]),
+    .b_addr_i  (mem_b_addr[AddrWidth-1:AOff]),
     .b_wdata_i (1'b0),
     .b_rdata_o (unused_mem_b_rcap)
   );
+
+  // Single-cycle read response.
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      mem_a_rvalid <= '0;
+      mem_b_rvalid <= '0;
+    end else begin
+      mem_a_rvalid <= mem_a_req & ~mem_a_we;
+      mem_b_rvalid <= mem_b_req & ~mem_b_we;
+    end
+  end
 
 endmodule

--- a/rtl/system/sram.sv
+++ b/rtl/system/sram.sv
@@ -26,21 +26,20 @@ module sram #(
   // Number of address bits to select a word from the SRAM.
   localparam int unsigned SramAw = AddrWidth - AOff;
 
-  logic                     mem_a_req;
-  logic [AddrWidth-1:AOff]  mem_a_addr;
-  logic                     mem_a_we;
-  logic [DataWidth-1:0]     mem_a_wmask;
-
-  logic [DataWidth-1:0]     mem_a_wdata;
-  logic                     mem_a_wcap;
-  logic                     mem_a_rvalid;
-  logic [DataWidth-1:0]     mem_a_rdata;
-  logic                     mem_a_rcap;
+  logic                    mem_a_req;
+  logic                    mem_a_we;
+  logic [AddrWidth-1:AOff] mem_a_addr;
+  logic [DataWidth-1:0]    mem_a_wmask;
+  logic [DataWidth-1:0]    mem_a_wdata;
+  logic                    mem_a_wcap;
+  logic                    mem_a_rvalid;
+  logic [DataWidth-1:0]    mem_a_rdata;
+  logic                    mem_a_rcap;
 
   logic                    mem_b_req;
   logic                    mem_b_we;
-  logic                    mem_b_rvalid;
   logic [AddrWidth-1:AOff] mem_b_addr;
+  logic                    mem_b_rvalid;
   logic [DataWidth-1:0]    mem_b_rdata;
   logic                    unused_mem_b_rcap;
 
@@ -53,11 +52,11 @@ module sram #(
     .rst_ni,
 
     // TL-UL interface.
-    .tl_i(tl_a_i),
-    .tl_o(tl_a_o),
+    .tl_i        (tl_a_i),
+    .tl_o        (tl_a_o),
 
     // Control interface.
-    .en_ifetch_i(prim_mubi_pkg::MuBi4False),
+    .en_ifetch_i (prim_mubi_pkg::MuBi4False),
 
     // SRAM interface.
     .req_o       (mem_a_req),
@@ -83,26 +82,26 @@ module sram #(
     .rst_ni,
 
     // TL-UL interface.
-    .tl_i(tl_b_i),
-    .tl_o(tl_b_o),
+    .tl_i        (tl_b_i),
+    .tl_o        (tl_b_o),
 
     // Control interface.
     .en_ifetch_i (prim_mubi_pkg::MuBi4True),
 
     // SRAM interface.
-    .req_o(mem_b_req),
-    .req_type_o(),
-    .gnt_i(mem_b_req),
-    .we_o(mem_b_we),
-    .addr_o(mem_b_addr),
-    .wdata_o(),
-    .wdata_cap_o(),
-    .wmask_o(),
+    .req_o       (mem_b_req),
+    .req_type_o  (),
+    .gnt_i       (mem_b_req),
+    .we_o        (mem_b_we),
+    .addr_o      (mem_b_addr),
+    .wdata_o     (),
+    .wdata_cap_o (),
+    .wmask_o     (),
     .intg_error_o(),
-    .rdata_i(mem_b_rdata),
-    .rdata_cap_i(1'b0),
-    .rvalid_i(mem_b_rvalid),
-    .rerror_i(2'b00)
+    .rdata_i     (mem_b_rdata),
+    .rdata_cap_i (1'b0),
+    .rvalid_i    (mem_b_rvalid),
+    .rerror_i    (2'b00)
   );
 
   // Number of words in data memory.

--- a/sw/cheri/tests/revocation_test.cc
+++ b/sw/cheri/tests/revocation_test.cc
@@ -7,7 +7,7 @@
 
 using namespace CHERI;
 
-#define CPU_FREQ_HZ (25'000'000)
+#define CPU_FREQ_HZ (30'000'000)
 #define BAUD_RATE   (   115'200)
 
 /**

--- a/sw/cheri/tests/spi_test.cc
+++ b/sw/cheri/tests/spi_test.cc
@@ -7,7 +7,7 @@
 
 using namespace CHERI;
 
-#define CPU_FREQ_HZ (25'000'000)
+#define CPU_FREQ_HZ (30'000'000)
 #define BAUD_RATE   (   115'200)
 
 /**

--- a/sw/cheri/tests/uart_check.cc
+++ b/sw/cheri/tests/uart_check.cc
@@ -9,7 +9,7 @@
 using namespace CHERI;
 
 #define GPIO_VALUE  (0xFFFFFFFF)
-#define CPU_FREQ_HZ (50'000'000)
+#define CPU_FREQ_HZ (30'000'000)
 #define BAUD_RATE   (   115'200)
 
 /**

--- a/sw/legacy/common/sonata_system.h
+++ b/sw/legacy/common/sonata_system.h
@@ -13,7 +13,7 @@
 #include "uart.h"
 
 // System Clock Frequency (Hz)
-#define SYSCLK_FREQ (25*1000*1000)
+#define SYSCLK_FREQ (30*1000*1000)
 
 #define UART_IRQ_NUM 16
 #define UART_IRQ (1 << UART_IRQ_NUM)

--- a/sw/legacy/demo/hello_world/main.c
+++ b/sw/legacy/demo/hello_world/main.c
@@ -29,8 +29,8 @@ int main(void) {
   uart_init(DEFAULT_UART);
 
   // This indicates how often the timer gets updated.
-//  timer_init();
-//  timer_enable(5000000);
+  timer_init();
+  timer_enable(5000000);
 
   uint64_t last_elapsed_time = get_elapsed_time();
 
@@ -63,7 +63,7 @@ int main(void) {
       putchar('\n');
 
       // Re-enable interrupts with output complete
-//      arch_local_irq_enable();
+      arch_local_irq_enable();
 
       // Cycling through green LEDs
       if (USE_GPIO_SHIFT_REG) {

--- a/sw/legacy/link.ld
+++ b/sw/legacy/link.ld
@@ -6,13 +6,13 @@ OUTPUT_ARCH(riscv)
 
 MEMORY
 {
-    /* 124 KiB should be enough for anybody... */
-    ram         : ORIGIN = 0x00100000, LENGTH = 0x1E000 /* 124 KiB */
-    stack       : ORIGIN = 0x0011E000, LENGTH = 0x02000  /*  4 KiB */
+    /* 256 KiB should be enough for anybody... */
+    ram         : ORIGIN = 0x00100000, LENGTH = 0x3F000 /* 252 KiB */
+    stack       : ORIGIN = 0x0013F000, LENGTH = 0x01000   /* 4 KiB */
 }
 
 /* Stack information variables */
-_min_stack      = 0x1000;   /* 4K - minimum stack space to reserve */
+_min_stack     = 0x1000;   /* 4KiB - minimum stack space to reserve */
 _stack_len     = LENGTH(stack);
 _stack_start   = ORIGIN(stack) + LENGTH(stack);
 

--- a/sw/legacy/test/memory_test.c
+++ b/sw/legacy/test/memory_test.c
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This test is useful when making changes to the memory sub-system.
-// It first tests writing data to RAM and reading it back.
+// It first performs a basic word write/read test of the RAM.
+// It then proceeds to test byte read/writes.
 // Then it writes to a peripheral register and checks the value that is read back.
-// At the moment it passes and fails using an infinite while loop so that you can check the result using a wave output from simulation.
+// At the moment it passes and fails using an infinite while loop so that you can
+// check the result using a wave output from simulation.
 
 #include <stdbool.h>
 
@@ -13,30 +15,54 @@
 #include "sonata_system.h"
 #include "timer.h"
 
-#define TEST_DATA (0xDEADFEEF)
-#define TEST_SIZE (5)
+#define TEST_DATA (0xDEADBEEF)
+#define TEST_SIZE ((224*1024)/4)
 
-int test_array[TEST_SIZE];
+static uint32_t test_array[TEST_SIZE];
 
 int pass() {
+  puts("Passed");
+
   while(true);
   return 0;
 }
 
 int fail() {
+  puts("Failed");
+
   while(true);
   return -1;
 }
 
 int main(void) {
-  // RAM test
+  uart_init(DEFAULT_UART);
+
+  putstr("memory_test running...");
+  puthex(TEST_SIZE * 4);
+  puts(" bytes");
+
+  // Simple word write/read test of most of the RAM; some RAM is used by the
+  // code itself, global static and stack...
   for (int i = 0; i < TEST_SIZE; i++) {
-    // Write data
     test_array[i] = TEST_DATA + i;
   }
+  // Read back data and check it is correct
   for (int i = 0; i < TEST_SIZE; i++) {
-    // Read back data and check it is correct
     if (test_array[i] != TEST_DATA + i) {
+      return fail();
+    }
+  }
+
+  // Byte read/write test
+  uint8_t *btest = (uint8_t*)test_array;
+  for (int i = 0; i < TEST_SIZE; i++) {
+    btest[i * 4 + (i & 3)] ^= i;
+  }
+  // Read back data and check it is correct
+  for (int i = 0; i < TEST_SIZE; i++) {
+    uint32_t orig = TEST_DATA + i;
+    uint32_t mod  = orig ^ (uint8_t)i << (8 * (i & 3));
+    if (test_array[i] != mod) {
       return fail();
     }
   }


### PR DESCRIPTION
- Increase SRAM size to 256KiB by avoiding bit-level write enables.
- Increase system clock frequency to 30MHz (just misses timing at 33MHz presently).
- Resurrect legacy 'hello_word' demo application now that rv_timer is usable.

This build is timing clean on A50T and passes legacy code tests (memory_test, i2c_hat_id, hello_world, hello_usb) and hello_compartment from the CHERIoT RTOS world.