### PR TITLE
DOC: Mention programming the RP2040 as a default step

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,6 +3,7 @@
 [Introduction](README.md)
 
 - [Getting started](doc/guide/getting-started.md)
+  - [Reloading the RP2040](doc/guide/rp2040-update.md)
   - [Reloading the FPGA Image](doc/guide/fpga-update.md)
   - [Software Toolchain Setup](doc/guide/toolchain-setup.md)
   - [Building Examples](doc/guide/building-examples.md)

--- a/doc/guide/getting-started.md
+++ b/doc/guide/getting-started.md
@@ -10,8 +10,10 @@ default setups.
 
 ## Getting Started Steps
 
-To get started with your Sonata board, there are three steps you'll need to do:
+To get started with your Sonata board, there are three steps you'll need to do. First, head to
+the [Sonata System Release Page](https://github.com/lowRISC/sonata-system/releases/) where you'll find the latest releases.
 
+0. [Program the RP2040 With the Latest](rp2040-update.md) firmware to get any bug fixes by entering bootloader mode & dragging the `rpi_rp2_v0.XX.uf2`.
 1. [Get the latest FPGA image](fpga-update.md) that corresponds with the software you are building. This requires you to just drag the new `.bit` file onto the SONATA drive that comes up when you plug in the board to your computer.
 2. [Install the software toolchain](toolchain-setup.md).
 3. [Build the example code](building-examples.md) and download to the soft-core you loaded in step 1.

--- a/doc/guide/rp2040-update.md
+++ b/doc/guide/rp2040-update.md
@@ -1,0 +1,12 @@
+# Reloading the RP2040 USB Controller
+
+Before plugging in your Sonata board, hold down the SW9 labelled "RP2040 Boot", and while holding this button plug your board into your laptop using the Main USB.
+
+A drive called RPI-RP2 should pop up on your computer and drag `rpi_rp2_v0.X.uf2` into it.
+This drive should automatically dismount once the file is transferred and remount as SONATA.
+
+## Downloading the `rpi_rp2_v.X.uf2` file
+
+Currently the RP2040 firmware is available from the [Sonata Systems](https://github.com/lowRISC/sonata-system/releases) releases, which ensures your RP2040 firmware matches the Sonata FPGA and firmware expectations.
+
+The source & latest release for the RP2040 are also found on the [Sonata RP2040 repo](https://github.com/newaetech/sonata-rp2040/releases).


### PR DESCRIPTION
Matches the release quickstart guide now. Eventually could make this step optional, but during active development I think makes sense to tell people to always do it.