### PR TITLE
Use Sonata JTAG IDCODE instead of demo system

### DIFF
--- a/rtl/system/jtag_id_pkg.sv
+++ b/rtl/system/jtag_id_pkg.sv
@@ -10,7 +10,7 @@ package jtag_id_pkg;
 
   localparam logic [31:0] RV_DM_JTAG_IDCODE = {
     JTAG_VERSION,          // Version
-    {12'h100,4'h1},        // Part Number
+    {12'h101,4'h1},        // Sonata part number
     JEDEC_MANUFACTURER_ID, // Manufacturer ID
     1'b1                   // (fixed)
   };

--- a/util/sonata-openocd-cfg.tcl
+++ b/util/sonata-openocd-cfg.tcl
@@ -12,8 +12,8 @@ ftdi_layout_init 0x0088 0x008b
 # Configure JTAG chain and the target processor
 set _CHIPNAME riscv
 
-# Ibex Demo System JTAG IDCODE
-set _EXPECTED_ID 0x11001CDF
+# Sonata JTAG IDCODE
+set _EXPECTED_ID 0x11011CDF
 
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id $_EXPECTED_ID -ignore-version
 set _TARGETNAME $_CHIPNAME.cpu


### PR DESCRIPTION
This is according to lowRISC's part number registry: https://github.com/lowRISC/part-number-registry/blob/main/jtag_partno.md