### PR TITLE
Fixed alignment problem in error_leds program

### DIFF
--- a/sw/cheri/error_leds/error.S
+++ b/sw/cheri/error_leds/error.S
@@ -120,7 +120,7 @@ accesssystemregister:
 	j fail // We should never get here.
 
 // Trap handler must be 4 byte aligned.
-.section .trap, "ax", @progbits
+.section .text.trap, "ax", @progbits
 .p2align 2
 trap:
 	li t0, 0x01000000 //0x10 for simulation 0x01000000 for FPGA.


### PR DESCRIPTION
Programs need to be 4 byte aligned for srec to happliy convert them to vmem files. The `.trap` section wasn't in the linker script, which meant the ALIGN function in the linker script wasn't of any use.

Too see build error make this change on current main (https://github.com/lowRISC/sonata-system/commit/e7c62e713caccd17e169804da4f9009d6ada7d42).

```diff
diff --git a/sw/cheri/error_leds/error.S b/sw/cheri/error_leds/error.S
index b6967bb..36e9e20 100644
--- a/sw/cheri/error_leds/error.S
+++ b/sw/cheri/error_leds/error.S
@@ -123,7 +123,7 @@ accesssystemregister:
 .section .text.trap, "ax", @progbits
 .p2align 2
 trap:
-       li t0, 0x01000000 //0x10 for simulation 0x01000000 for FPGA.
+       li t0, 0x00000010 //0x10 for simulation 0x01000000 for FPGA.
 delayloop: // Delay clearing error LEDs so that you can see them.
        addi t0, t0, -1
        bnez t0, delayloop

```