### PR TITLE
Fade capability LEDs when switching off

### DIFF
--- a/rtl/system/pwm_fade.sv
+++ b/rtl/system/pwm_fade.sv
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * This module will assert it's output, `modulated_o`,
+ * when `impulse_i` is asserted. When `impulse_i` is dropped,
+ * it will fade it's output by decreasing it's pulse width.
+ *
+ * Total fade time = (1 << PwmCounterSize)^2 * NumPeriods * the clock period
+ * The default fade time is 2.24 second, when the clock is 30MHz
+ */
+module pwm_fade #(
+  /// The size of the pwm counter.
+  parameter PwmCounterSize = 7,
+  /// The number of pwm periods between pulse width reductions.
+  parameter NumPeriods = (1 << 12) - 1
+)(
+  input logic clk_i,
+  input logic rst_ni,
+  input logic impulse_i,
+
+  output logic modulated_o
+);
+  localparam PwmCounterMax = (1 << PwmCounterSize) - 1;
+
+  logic [$clog2(NumPeriods+1)+PwmCounterSize:0] counter;
+  logic [PwmCounterSize-1:0] pwm_counter, pulse_width;
+
+  // The bottom `PwmCounterSize` bits of the counter
+  // are used as the pwm counter.
+  assign pwm_counter = counter[PwmCounterSize-1:0];
+
+  assign modulated_o = pwm_counter < pulse_width;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : main
+    if (!rst_ni) begin
+      pulse_width <= 0;
+      counter <= 0;
+    end else if (impulse_i != 0) begin
+      pulse_width <= PwmCounterMax;
+      counter <= 0;
+    end else if (pulse_width != 0) begin
+      if (counter == (NumPeriods << PwmCounterSize)) begin
+        pulse_width <= pulse_width - 1;
+        counter <= 0;
+      end else begin
+        counter <= counter + 1;
+      end
+    end
+  end : main
+endmodule : pwm_fade

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -798,6 +798,17 @@ module sonata_system #(
   assign cheri_en_o = cheri_en;
   assign rst_core_n = rst_sys_ni & ~ndmreset_req & dbg_release_core;
 
+  logic [CheriErrWidth-1:0] cheri_err;
+
+  for (genvar i = 0; i < CheriErrWidth; ++i) begin : gen_pwm_fade
+    pwm_fade u_pwm_fade (
+      .clk_i       (clk_sys_i      ),
+      .rst_ni      (rst_core_n     ),
+      .impulse_i   (cheri_err[i]   ),
+      .modulated_o (cheri_err_o[i] )
+    );
+  end
+
   ibexc_top_tracing #(
     .DmHaltAddr      ( DebugStart + dm::HaltAddress[31:0]      ),
     .DmExceptionAddr ( DebugStart + dm::ExceptionAddress[31:0] ),
@@ -819,7 +830,7 @@ module sonata_system #(
 
     .cheri_pmode_i          (cheri_en),
     .cheri_tsafe_en_i       (cheri_en),
-    .cheri_err_o            (cheri_err_o),
+    .cheri_err_o            (cheri_err),
 
     .hart_id_i              (32'b0),
     // First instruction executed is at 0x0010_0000 + 0x80.

--- a/sonata_system.core
+++ b/sonata_system.core
@@ -26,6 +26,7 @@ filesets:
       - rtl/system/gpio.sv
       - rtl/system/pwm.sv
       - rtl/system/pwm_wrapper.sv
+      - rtl/system/pwm_fade.sv
       - rtl/system/sram.sv
       - rtl/system/rv_timer.sv
     file_type: systemVerilogSource


### PR DESCRIPTION
This is done with a new `pwm_fade` block, placed between the error signal from the core and the led output.