### PR TITLE
Fix bootloader to avoid return sentry

### DIFF
--- a/sw/cheri/boot/boot.S
+++ b/sw/cheri/boot/boot.S
@@ -30,5 +30,5 @@ start:
 	// and we have 32 KiB of IROM so wasting a few bytes doesn't really matter.
 	auipcc           cra, 0
 	li               t0, 0x00101000
-	csetaddr         cra, cra, t0
-	cjr              cra
+	csetaddr         ct0, cra, t0
+	cjr              ct0


### PR DESCRIPTION
`cjr cra` requires `cra` to be a return sentry in newer version of CHERIoT Ibex. Use `ct0` instead to avoid this problem.

Based on this commit:
https://github.com/CHERIoT-Platform/cheriot-safe-uart-boot-rom/commit/82fbc153075b2532b124a9eb1c223d1e61666e3b

Fixes: https://github.com/lowRISC/sonata-system/issues/134