### PR TITLE
Increased the default baud rate

### DIFF
--- a/doc/guide/building-examples.md
+++ b/doc/guide/building-examples.md
@@ -1,6 +1,7 @@
 # Building Examples
 
-The following contains some simple examples you can build for the Sonata board. Once you've got these builds working, you can easily add more features to the example code.
+The following contains some simple examples you can build for the Sonata board.
+Once you've got these builds working, you can easily add more features to the example code.
 
 ## Using our template
 
@@ -37,9 +38,12 @@ On Mac this is similar
 screen /dev/tty.usbserial-LN100302 115200
 ```
 
-On Windows, connecting to serial ports directly from within WSL2 (default) is not possible. Connecting from WSL1 is possible, but we recommend to use [PuTTY](https://www.putty.org/) to connect to serial ports. Alternatively you can use [Termite](https://www.compuphase.com/software_termite.htm).
+On Windows, connecting to serial ports directly from within WSL2 (default) is not possible.
+Connecting from WSL1 is possible, but we recommend to use [PuTTY](https://www.putty.org/) to connect to serial ports.
+Alternatively you can use [Termite](https://www.compuphase.com/software_termite.htm).
 
-Select "Serial" as "Connection type", put the COM port in the "Serial line" text field, and set "Speed" to 115200. To find out what serial ports are available, you can open Device Manager and all connected serial ports are listed under "Ports (COM & LPT)" section.
+Select "Serial" as "Connection type", put the COM port in the "Serial line" text field, and set "Speed" to 115200.
+To find out what serial ports are available, you can open Device Manager and all connected serial ports are listed under "Ports (COM & LPT)" section.
 
 ## Baremetal examples
 
@@ -101,4 +105,5 @@ You can load software onto the FPGA over USB (JTAG) using:
 ```sh
 ./util/mem_helper.sh load_program -e sw/cheri/build/tests/spi_test
 ```
-There are actually four different ways of loading the program - we normally use JTAG for development, but you can also program it into the serial flash device on the board. See the page [Programming the Sonata Software](../dev/sw-programming.md).
+There are actually four different ways of loading the program - we normally use JTAG for development, but you can also program it into the serial flash device on the board.
+See the page [Programming the Sonata Software](../dev/sw-programming.md).

--- a/doc/guide/building-examples.md
+++ b/doc/guide/building-examples.md
@@ -30,19 +30,19 @@ You can drag and drop this UF2 file into the `SONATA` drive to program the firmw
 
 On Linux use the following command to check you can receive serial output:
 ```sh
-screen /dev/ttyUSB2 115200
+screen /dev/ttyUSB2 921600
 ```
 
 On Mac this is similar
 ```sh
-screen /dev/tty.usbserial-LN100302 115200
+screen /dev/tty.usbserial-LN100302 921600
 ```
 
 On Windows, connecting to serial ports directly from within WSL2 (default) is not possible.
 Connecting from WSL1 is possible, but we recommend to use [PuTTY](https://www.putty.org/) to connect to serial ports.
 Alternatively you can use [Termite](https://www.compuphase.com/software_termite.htm).
 
-Select "Serial" as "Connection type", put the COM port in the "Serial line" text field, and set "Speed" to 115200.
+Select "Serial" as "Connection type", put the COM port in the "Serial line" text field, and set "Speed" to 921600.
 To find out what serial ports are available, you can open Device Manager and all connected serial ports are listed under "Ports (COM & LPT)" section.
 
 ## Baremetal examples

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -6,7 +6,7 @@
 module top_verilator (input logic clk_i, rst_ni);
 
   localparam ClockFrequency = 30_000_000;
-  localparam BaudRate       = 115_200;
+  localparam BaudRate       = 921_600;
   localparam EnableCHERI    = 1'b1;
 
   logic uart_sys_rx, uart_sys_tx;

--- a/sw/cheri/boot/boot_loader.cc
+++ b/sw/cheri/boot/boot_loader.cc
@@ -128,7 +128,7 @@ extern "C" void rom_loader_entry(void *rwRoot)
 	sram.bounds()                    = 0x00040000 - 0x1000;
 
 	spi->init(false, false, true, 0);
-	uart->init();
+	uart->init(BAUD_RATE);
 
 	SpiFlash spi_flash(spi, gpio, FLASH_CSN_GPIO_BIT);
 	read_elf(spi_flash, uart, sram);

--- a/sw/cheri/tests/spi_test.cc
+++ b/sw/cheri/tests/spi_test.cc
@@ -42,7 +42,7 @@ using namespace CHERI;
 	SpiFlash spi_flash(spi, gpio, FLASH_CSN_GPIO_BIT);
 
 	spi->init(false, false, true, 0);
-	uart->init();
+	uart->init(BAUD_RATE);
 	write_str(uart, "Hello World!\r\n");
 
 	uint8_t jedec_id[3];

--- a/sw/common/defs.h
+++ b/sw/common/defs.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #define CPU_TIMER_HZ (30'000'000)
-#define BAUD_RATE    (   115'200)
+#define BAUD_RATE    (   921'600)
 
 #define RGBLED_CTRL_ADDRESS (0x8000'9000)
 #define RGBLED_CTRL_BOUNDS  (0x0000'0010)

--- a/sw/legacy/common/uart.c
+++ b/sw/legacy/common/uart.c
@@ -7,7 +7,7 @@
 #include "sonata_system.h"
 #include "dev_access.h"
 
-#define BAUD_RATE (115200)
+#define BAUD_RATE (921600)
 
 void uart_enable_rx_int(void) {
   enable_interrupts(UART_IRQ);


### PR DESCRIPTION
The motivation for changing this is to speed up the CHERIoT RTOS test suite that spends a lot of time waiting for UART.
Changing to 921,600 from 115,200 decreased the runtime from 20 to 6 minutes.

I chose 921,600 because it is the closest standard baud rate to the maximum possible baud rate of 937,500.[^1] This is very close the the maximum, but the error (0.55 cycles) hasn't caused problems in simulation or on FPGA.

[^1]: The UART divides the clock by 16 (for over sampling on the receive side) and then by 2, so the maximum baud rate is the clock divided by 32. The clock is currently 30,000,000 so the maximum baud rate is 937,500. The closest standard baud rate below this is 921,600.
