### PR TITLE
Reset SPI flash before accessing it

### DIFF
--- a/sw/cheri/boot/boot_loader.cc
+++ b/sw/cheri/boot/boot_loader.cc
@@ -131,6 +131,7 @@ extern "C" void rom_loader_entry(void *rwRoot)
 	uart->init(BAUD_RATE);
 
 	SpiFlash spi_flash(spi, gpio, FLASH_CSN_GPIO_BIT);
+	spi_flash.reset();
 	read_elf(spi_flash, uart, sram);
 
 	write_str(uart, prefix);

--- a/sw/cheri/common/timer-utils.hh
+++ b/sw/cheri/common/timer-utils.hh
@@ -1,0 +1,20 @@
+#pragma once
+#include <stdint.h>
+
+static inline uint32_t get_mcycle(void)
+{
+	uint32_t result;
+	asm volatile("csrr %0, mcycle;" : "=r"(result));
+	return result;
+}
+
+static inline void reset_mcycle(void)
+{
+	asm volatile("csrw mcycle, x0");
+}
+
+static inline void wait_mcycle(uint32_t value)
+{
+	reset_mcycle();
+	while (get_mcycle() < value) {}
+}


### PR DESCRIPTION
If the system is reset while a SPI access is going on, the SPI device might not be in the correct state and using it directly will fail, and we don't show helpful message in this case, just "Failed ELF Magic Check".

Add a software reset sequence to reset it to a well known state before accessing.