### PR TITLE
HyperRAM fix and improvements

### DIFF
--- a/rtl/ip/hyperram/rtl/hbmc_tl_top.sv
+++ b/rtl/ip/hyperram/rtl/hbmc_tl_top.sv
@@ -267,6 +267,7 @@ module hbmc_tl_top import tlul_pkg::*; #(
   always_comb begin
     tl_o_int           = '0;
     tl_req_fifo_rready = 1'b0;
+    ufifo_rd_ena       = 1'b0;
 
     if (tl_req_fifo_rvalid) begin
       // We have an incoming request that needs a response


### PR DESCRIPTION
Two changes made:
* HyperRAM controller tag RAM's cmd and wdata FIFO get merged into one. There's only 1 bit for the data so there isn't much need to separate cmd and data FIFO.
* Initialise `ufifo_rd_ena` in the beginning of `always_comb` block to zero. Otherwise Vivado will infer it as a latch.