### PR TITLE
Add XADC

### DIFF
--- a/data/pins_sonata.xdc
+++ b/data/pins_sonata.xdc
@@ -247,6 +247,28 @@ set_property -dict { PACKAGE_PIN U13 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio3]
 set_property -dict { PACKAGE_PIN R12 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio2];
 set_property -dict { PACKAGE_PIN U12 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio1];
 set_property -dict { PACKAGE_PIN T11 IOSTANDARD LVCMOS33 } [get_ports ah_tmpio0];
+## Digital inputs from analog(ue) pins via 1k resistor
+set_property -dict { PACKAGE_PIN G13 IOSTANDARD LVCMOS33 } [get_ports {ard_an_di[0]}];
+set_property -dict { PACKAGE_PIN D14 IOSTANDARD LVCMOS33 } [get_ports {ard_an_di[1]}];
+set_property -dict { PACKAGE_PIN C14 IOSTANDARD LVCMOS33 } [get_ports {ard_an_di[2]}];
+set_property -dict { PACKAGE_PIN C9  IOSTANDARD LVCMOS33 } [get_ports {ard_an_di[3]}];
+set_property -dict { PACKAGE_PIN B9  IOSTANDARD LVCMOS33 } [get_ports {ard_an_di[4]}];
+set_property -dict { PACKAGE_PIN B8  IOSTANDARD LVCMOS33 } [get_ports {ard_an_di[5]}];
+## Analog(ue) input pairs from analog(ue) pins via buffer and impedance network
+## UG480: "...an IOSTANDARD must be selected that is compatible for the bank
+##         even though the IOSTANDARD does not affect the input programming."
+set_property -dict { PACKAGE_PIN C6  IOSTANDARD LVCMOS18 } [get_ports {ard_an_p[0]}]; # VAUX4P
+set_property -dict { PACKAGE_PIN C5  IOSTANDARD LVCMOS18 } [get_ports {ard_an_n[0]}]; # VAUX4N
+set_property -dict { PACKAGE_PIN B7  IOSTANDARD LVCMOS18 } [get_ports {ard_an_p[1]}]; # VAUX12P
+set_property -dict { PACKAGE_PIN B6  IOSTANDARD LVCMOS18 } [get_ports {ard_an_n[1]}]; # VAUX12N
+set_property -dict { PACKAGE_PIN A6  IOSTANDARD LVCMOS18 } [get_ports {ard_an_p[2]}]; # VAUX5P
+set_property -dict { PACKAGE_PIN A5  IOSTANDARD LVCMOS18 } [get_ports {ard_an_n[2]}]; # VAUX5N
+set_property -dict { PACKAGE_PIN E6  IOSTANDARD LVCMOS18 } [get_ports {ard_an_p[3]}]; # VAUX13P
+set_property -dict { PACKAGE_PIN E5  IOSTANDARD LVCMOS18 } [get_ports {ard_an_n[3]}]; # VAUX13N
+set_property -dict { PACKAGE_PIN C4  IOSTANDARD LVCMOS18 } [get_ports {ard_an_p[4]}]; # VAUX6P
+set_property -dict { PACKAGE_PIN B4  IOSTANDARD LVCMOS18 } [get_ports {ard_an_n[4]}]; # VAUX6N
+set_property -dict { PACKAGE_PIN A4  IOSTANDARD LVCMOS18 } [get_ports {ard_an_p[5]}]; # VAUX14P
+set_property -dict { PACKAGE_PIN A3  IOSTANDARD LVCMOS18 } [get_ports {ard_an_n[5]}]; # VAUX14N
 
 ## RGB LED
 set_property -dict { PACKAGE_PIN D9  IOSTANDARD LVCMOS33 } [get_ports rgbled0]

--- a/data/xbar_main.hjson
+++ b/data/xbar_main.hjson
@@ -129,6 +129,16 @@
         size_byte: "0x00001000",
       }],
     },
+    { name:  "xadc", // XADC
+      type:  "device",
+      clock: "clk_sys_i",
+      reset: "rst_sys_ni",
+      xbar:  false,
+      addr_range: [{
+        base_addr: "0x8000B000",
+        size_byte: "0x00001000",
+      }],
+    },
     { name:  "timer", // Interrupt timer
       type:  "device",
       clock: "clk_sys_i",
@@ -313,6 +323,7 @@
       "pmod_gpio",
       "rgbled_ctrl",
       "hw_rev",
+      "xadc",
       "timer",
       "uart0",
       "uart1",

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -62,6 +62,10 @@ module top_verilator (input logic clk_i, rst_ni);
     .pmod_gp_i(0),
     .pmod_gp_o( ),
 
+    .ard_an_di_i(0),
+    .ard_an_p_i (0),
+    .ard_an_n_i (0),
+
     // UART 0 TX and RX
     .uart0_rx_i     (uart_sys_rx),
     .uart0_tx_o     (uart_sys_tx),

--- a/rtl/bus/tl_main_pkg.sv
+++ b/rtl/bus/tl_main_pkg.sv
@@ -16,6 +16,7 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_SPACE_PMOD_GPIO   = 32'h 80008000;
   localparam logic [31:0] ADDR_SPACE_RGBLED_CTRL = 32'h 80009000;
   localparam logic [31:0] ADDR_SPACE_HW_REV      = 32'h 8000a000;
+  localparam logic [31:0] ADDR_SPACE_XADC        = 32'h 8000b000;
   localparam logic [31:0] ADDR_SPACE_TIMER       = 32'h 80040000;
   localparam logic [31:0] ADDR_SPACE_UART0       = 32'h 80100000;
   localparam logic [31:0] ADDR_SPACE_UART1       = 32'h 80101000;
@@ -44,6 +45,7 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_MASK_PMOD_GPIO   = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_RGBLED_CTRL = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_HW_REV      = 32'h 00000fff;
+  localparam logic [31:0] ADDR_MASK_XADC        = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_TIMER       = 32'h 0000ffff;
   localparam logic [31:0] ADDR_MASK_UART0       = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_UART1       = 32'h 00000fff;
@@ -63,7 +65,7 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_MASK_RV_PLIC     = 32'h 03ffffff;
 
   localparam int N_HOST   = 2;
-  localparam int N_DEVICE = 27;
+  localparam int N_DEVICE = 28;
 
   typedef enum int {
     TlSram = 0,
@@ -76,23 +78,24 @@ package tl_main_pkg;
     TlPmodGpio = 7,
     TlRgbledCtrl = 8,
     TlHwRev = 9,
-    TlTimer = 10,
-    TlUart0 = 11,
-    TlUart1 = 12,
-    TlUart2 = 13,
-    TlUart3 = 14,
-    TlUart4 = 15,
-    TlI2C0 = 16,
-    TlI2C1 = 17,
-    TlSpiFlash = 18,
-    TlSpiLcd = 19,
-    TlSpiEth = 20,
-    TlSpiRp0 = 21,
-    TlSpiRp1 = 22,
-    TlSpiArd = 23,
-    TlSpiMkr = 24,
-    TlUsbdev = 25,
-    TlRvPlic = 26
+    TlXadc = 10,
+    TlTimer = 11,
+    TlUart0 = 12,
+    TlUart1 = 13,
+    TlUart2 = 14,
+    TlUart3 = 15,
+    TlUart4 = 16,
+    TlI2C0 = 17,
+    TlI2C1 = 18,
+    TlSpiFlash = 19,
+    TlSpiLcd = 20,
+    TlSpiEth = 21,
+    TlSpiRp0 = 22,
+    TlSpiRp1 = 23,
+    TlSpiArd = 24,
+    TlSpiMkr = 25,
+    TlUsbdev = 26,
+    TlRvPlic = 27
   } tl_device_e;
 
   typedef enum int {

--- a/rtl/bus/xbar_main.sv
+++ b/rtl/bus/xbar_main.sv
@@ -7,8 +7,8 @@
 //
 // Interconnect
 // ibex_lsu
-//   -> s1n_29
-//     -> sm1_30
+//   -> s1n_30
+//     -> sm1_31
 //       -> sram
 //     -> hyperram
 //     -> rev_tag
@@ -19,6 +19,7 @@
 //     -> pmod_gpio
 //     -> rgbled_ctrl
 //     -> hw_rev
+//     -> xadc
 //     -> timer
 //     -> uart0
 //     -> uart1
@@ -34,11 +35,11 @@
 //     -> spi_rp1
 //     -> spi_ard
 //     -> spi_mkr
-//     -> asf_31
+//     -> asf_32
 //       -> usbdev
 //     -> rv_plic
 // dbg_host
-//   -> sm1_30
+//   -> sm1_31
 //     -> sram
 
 module xbar_main (
@@ -74,6 +75,8 @@ module xbar_main (
   input  tlul_pkg::tl_d2h_t tl_rgbled_ctrl_i,
   output tlul_pkg::tl_h2d_t tl_hw_rev_o,
   input  tlul_pkg::tl_d2h_t tl_hw_rev_i,
+  output tlul_pkg::tl_h2d_t tl_xadc_o,
+  input  tlul_pkg::tl_d2h_t tl_xadc_i,
   output tlul_pkg::tl_h2d_t tl_timer_o,
   input  tlul_pkg::tl_d2h_t tl_timer_i,
   output tlul_pkg::tl_h2d_t tl_uart0_o,
@@ -120,233 +123,240 @@ module xbar_main (
   logic unused_scanmode;
   assign unused_scanmode = ^scanmode_i;
 
-  tl_h2d_t tl_s1n_29_us_h2d ;
-  tl_d2h_t tl_s1n_29_us_d2h ;
+  tl_h2d_t tl_s1n_30_us_h2d ;
+  tl_d2h_t tl_s1n_30_us_d2h ;
 
 
-  tl_h2d_t tl_s1n_29_ds_h2d [27];
-  tl_d2h_t tl_s1n_29_ds_d2h [27];
+  tl_h2d_t tl_s1n_30_ds_h2d [28];
+  tl_d2h_t tl_s1n_30_ds_d2h [28];
 
   // Create steering signal
-  logic [4:0] dev_sel_s1n_29;
+  logic [4:0] dev_sel_s1n_30;
 
 
-  tl_h2d_t tl_sm1_30_us_h2d [2];
-  tl_d2h_t tl_sm1_30_us_d2h [2];
+  tl_h2d_t tl_sm1_31_us_h2d [2];
+  tl_d2h_t tl_sm1_31_us_d2h [2];
 
-  tl_h2d_t tl_sm1_30_ds_h2d ;
-  tl_d2h_t tl_sm1_30_ds_d2h ;
+  tl_h2d_t tl_sm1_31_ds_h2d ;
+  tl_d2h_t tl_sm1_31_ds_d2h ;
 
-  tl_h2d_t tl_asf_31_us_h2d ;
-  tl_d2h_t tl_asf_31_us_d2h ;
-  tl_h2d_t tl_asf_31_ds_h2d ;
-  tl_d2h_t tl_asf_31_ds_d2h ;
+  tl_h2d_t tl_asf_32_us_h2d ;
+  tl_d2h_t tl_asf_32_us_d2h ;
+  tl_h2d_t tl_asf_32_ds_h2d ;
+  tl_d2h_t tl_asf_32_ds_d2h ;
 
 
 
-  assign tl_sm1_30_us_h2d[0] = tl_s1n_29_ds_h2d[0];
-  assign tl_s1n_29_ds_d2h[0] = tl_sm1_30_us_d2h[0];
+  assign tl_sm1_31_us_h2d[0] = tl_s1n_30_ds_h2d[0];
+  assign tl_s1n_30_ds_d2h[0] = tl_sm1_31_us_d2h[0];
 
-  assign tl_hyperram_o = tl_s1n_29_ds_h2d[1];
-  assign tl_s1n_29_ds_d2h[1] = tl_hyperram_i;
+  assign tl_hyperram_o = tl_s1n_30_ds_h2d[1];
+  assign tl_s1n_30_ds_d2h[1] = tl_hyperram_i;
 
-  assign tl_rev_tag_o = tl_s1n_29_ds_h2d[2];
-  assign tl_s1n_29_ds_d2h[2] = tl_rev_tag_i;
+  assign tl_rev_tag_o = tl_s1n_30_ds_h2d[2];
+  assign tl_s1n_30_ds_d2h[2] = tl_rev_tag_i;
 
-  assign tl_gpio_o = tl_s1n_29_ds_h2d[3];
-  assign tl_s1n_29_ds_d2h[3] = tl_gpio_i;
+  assign tl_gpio_o = tl_s1n_30_ds_h2d[3];
+  assign tl_s1n_30_ds_d2h[3] = tl_gpio_i;
 
-  assign tl_pwm_o = tl_s1n_29_ds_h2d[4];
-  assign tl_s1n_29_ds_d2h[4] = tl_pwm_i;
+  assign tl_pwm_o = tl_s1n_30_ds_h2d[4];
+  assign tl_s1n_30_ds_d2h[4] = tl_pwm_i;
 
-  assign tl_rpi_gpio_o = tl_s1n_29_ds_h2d[5];
-  assign tl_s1n_29_ds_d2h[5] = tl_rpi_gpio_i;
+  assign tl_rpi_gpio_o = tl_s1n_30_ds_h2d[5];
+  assign tl_s1n_30_ds_d2h[5] = tl_rpi_gpio_i;
 
-  assign tl_ard_gpio_o = tl_s1n_29_ds_h2d[6];
-  assign tl_s1n_29_ds_d2h[6] = tl_ard_gpio_i;
+  assign tl_ard_gpio_o = tl_s1n_30_ds_h2d[6];
+  assign tl_s1n_30_ds_d2h[6] = tl_ard_gpio_i;
 
-  assign tl_pmod_gpio_o = tl_s1n_29_ds_h2d[7];
-  assign tl_s1n_29_ds_d2h[7] = tl_pmod_gpio_i;
+  assign tl_pmod_gpio_o = tl_s1n_30_ds_h2d[7];
+  assign tl_s1n_30_ds_d2h[7] = tl_pmod_gpio_i;
 
-  assign tl_rgbled_ctrl_o = tl_s1n_29_ds_h2d[8];
-  assign tl_s1n_29_ds_d2h[8] = tl_rgbled_ctrl_i;
+  assign tl_rgbled_ctrl_o = tl_s1n_30_ds_h2d[8];
+  assign tl_s1n_30_ds_d2h[8] = tl_rgbled_ctrl_i;
 
-  assign tl_hw_rev_o = tl_s1n_29_ds_h2d[9];
-  assign tl_s1n_29_ds_d2h[9] = tl_hw_rev_i;
+  assign tl_hw_rev_o = tl_s1n_30_ds_h2d[9];
+  assign tl_s1n_30_ds_d2h[9] = tl_hw_rev_i;
 
-  assign tl_timer_o = tl_s1n_29_ds_h2d[10];
-  assign tl_s1n_29_ds_d2h[10] = tl_timer_i;
+  assign tl_xadc_o = tl_s1n_30_ds_h2d[10];
+  assign tl_s1n_30_ds_d2h[10] = tl_xadc_i;
 
-  assign tl_uart0_o = tl_s1n_29_ds_h2d[11];
-  assign tl_s1n_29_ds_d2h[11] = tl_uart0_i;
+  assign tl_timer_o = tl_s1n_30_ds_h2d[11];
+  assign tl_s1n_30_ds_d2h[11] = tl_timer_i;
 
-  assign tl_uart1_o = tl_s1n_29_ds_h2d[12];
-  assign tl_s1n_29_ds_d2h[12] = tl_uart1_i;
+  assign tl_uart0_o = tl_s1n_30_ds_h2d[12];
+  assign tl_s1n_30_ds_d2h[12] = tl_uart0_i;
 
-  assign tl_uart2_o = tl_s1n_29_ds_h2d[13];
-  assign tl_s1n_29_ds_d2h[13] = tl_uart2_i;
+  assign tl_uart1_o = tl_s1n_30_ds_h2d[13];
+  assign tl_s1n_30_ds_d2h[13] = tl_uart1_i;
 
-  assign tl_uart3_o = tl_s1n_29_ds_h2d[14];
-  assign tl_s1n_29_ds_d2h[14] = tl_uart3_i;
+  assign tl_uart2_o = tl_s1n_30_ds_h2d[14];
+  assign tl_s1n_30_ds_d2h[14] = tl_uart2_i;
 
-  assign tl_uart4_o = tl_s1n_29_ds_h2d[15];
-  assign tl_s1n_29_ds_d2h[15] = tl_uart4_i;
+  assign tl_uart3_o = tl_s1n_30_ds_h2d[15];
+  assign tl_s1n_30_ds_d2h[15] = tl_uart3_i;
 
-  assign tl_i2c0_o = tl_s1n_29_ds_h2d[16];
-  assign tl_s1n_29_ds_d2h[16] = tl_i2c0_i;
+  assign tl_uart4_o = tl_s1n_30_ds_h2d[16];
+  assign tl_s1n_30_ds_d2h[16] = tl_uart4_i;
 
-  assign tl_i2c1_o = tl_s1n_29_ds_h2d[17];
-  assign tl_s1n_29_ds_d2h[17] = tl_i2c1_i;
+  assign tl_i2c0_o = tl_s1n_30_ds_h2d[17];
+  assign tl_s1n_30_ds_d2h[17] = tl_i2c0_i;
 
-  assign tl_spi_flash_o = tl_s1n_29_ds_h2d[18];
-  assign tl_s1n_29_ds_d2h[18] = tl_spi_flash_i;
+  assign tl_i2c1_o = tl_s1n_30_ds_h2d[18];
+  assign tl_s1n_30_ds_d2h[18] = tl_i2c1_i;
 
-  assign tl_spi_lcd_o = tl_s1n_29_ds_h2d[19];
-  assign tl_s1n_29_ds_d2h[19] = tl_spi_lcd_i;
+  assign tl_spi_flash_o = tl_s1n_30_ds_h2d[19];
+  assign tl_s1n_30_ds_d2h[19] = tl_spi_flash_i;
 
-  assign tl_spi_eth_o = tl_s1n_29_ds_h2d[20];
-  assign tl_s1n_29_ds_d2h[20] = tl_spi_eth_i;
+  assign tl_spi_lcd_o = tl_s1n_30_ds_h2d[20];
+  assign tl_s1n_30_ds_d2h[20] = tl_spi_lcd_i;
 
-  assign tl_spi_rp0_o = tl_s1n_29_ds_h2d[21];
-  assign tl_s1n_29_ds_d2h[21] = tl_spi_rp0_i;
+  assign tl_spi_eth_o = tl_s1n_30_ds_h2d[21];
+  assign tl_s1n_30_ds_d2h[21] = tl_spi_eth_i;
 
-  assign tl_spi_rp1_o = tl_s1n_29_ds_h2d[22];
-  assign tl_s1n_29_ds_d2h[22] = tl_spi_rp1_i;
+  assign tl_spi_rp0_o = tl_s1n_30_ds_h2d[22];
+  assign tl_s1n_30_ds_d2h[22] = tl_spi_rp0_i;
 
-  assign tl_spi_ard_o = tl_s1n_29_ds_h2d[23];
-  assign tl_s1n_29_ds_d2h[23] = tl_spi_ard_i;
+  assign tl_spi_rp1_o = tl_s1n_30_ds_h2d[23];
+  assign tl_s1n_30_ds_d2h[23] = tl_spi_rp1_i;
 
-  assign tl_spi_mkr_o = tl_s1n_29_ds_h2d[24];
-  assign tl_s1n_29_ds_d2h[24] = tl_spi_mkr_i;
+  assign tl_spi_ard_o = tl_s1n_30_ds_h2d[24];
+  assign tl_s1n_30_ds_d2h[24] = tl_spi_ard_i;
 
-  assign tl_asf_31_us_h2d = tl_s1n_29_ds_h2d[25];
-  assign tl_s1n_29_ds_d2h[25] = tl_asf_31_us_d2h;
+  assign tl_spi_mkr_o = tl_s1n_30_ds_h2d[25];
+  assign tl_s1n_30_ds_d2h[25] = tl_spi_mkr_i;
 
-  assign tl_rv_plic_o = tl_s1n_29_ds_h2d[26];
-  assign tl_s1n_29_ds_d2h[26] = tl_rv_plic_i;
+  assign tl_asf_32_us_h2d = tl_s1n_30_ds_h2d[26];
+  assign tl_s1n_30_ds_d2h[26] = tl_asf_32_us_d2h;
 
-  assign tl_sm1_30_us_h2d[1] = tl_dbg_host_i;
-  assign tl_dbg_host_o = tl_sm1_30_us_d2h[1];
+  assign tl_rv_plic_o = tl_s1n_30_ds_h2d[27];
+  assign tl_s1n_30_ds_d2h[27] = tl_rv_plic_i;
 
-  assign tl_s1n_29_us_h2d = tl_ibex_lsu_i;
-  assign tl_ibex_lsu_o = tl_s1n_29_us_d2h;
+  assign tl_sm1_31_us_h2d[1] = tl_dbg_host_i;
+  assign tl_dbg_host_o = tl_sm1_31_us_d2h[1];
 
-  assign tl_sram_o = tl_sm1_30_ds_h2d;
-  assign tl_sm1_30_ds_d2h = tl_sram_i;
+  assign tl_s1n_30_us_h2d = tl_ibex_lsu_i;
+  assign tl_ibex_lsu_o = tl_s1n_30_us_d2h;
 
-  assign tl_usbdev_o = tl_asf_31_ds_h2d;
-  assign tl_asf_31_ds_d2h = tl_usbdev_i;
+  assign tl_sram_o = tl_sm1_31_ds_h2d;
+  assign tl_sm1_31_ds_d2h = tl_sram_i;
+
+  assign tl_usbdev_o = tl_asf_32_ds_h2d;
+  assign tl_asf_32_ds_d2h = tl_usbdev_i;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
-    dev_sel_s1n_29 = 5'd27;
-    if ((tl_s1n_29_us_h2d.a_address &
+    dev_sel_s1n_30 = 5'd28;
+    if ((tl_s1n_30_us_h2d.a_address &
          ~(ADDR_MASK_SRAM)) == ADDR_SPACE_SRAM) begin
-      dev_sel_s1n_29 = 5'd0;
+      dev_sel_s1n_30 = 5'd0;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_HYPERRAM)) == ADDR_SPACE_HYPERRAM) begin
-      dev_sel_s1n_29 = 5'd1;
+      dev_sel_s1n_30 = 5'd1;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_REV_TAG)) == ADDR_SPACE_REV_TAG) begin
-      dev_sel_s1n_29 = 5'd2;
+      dev_sel_s1n_30 = 5'd2;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_GPIO)) == ADDR_SPACE_GPIO) begin
-      dev_sel_s1n_29 = 5'd3;
+      dev_sel_s1n_30 = 5'd3;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_PWM)) == ADDR_SPACE_PWM) begin
-      dev_sel_s1n_29 = 5'd4;
+      dev_sel_s1n_30 = 5'd4;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_RPI_GPIO)) == ADDR_SPACE_RPI_GPIO) begin
-      dev_sel_s1n_29 = 5'd5;
+      dev_sel_s1n_30 = 5'd5;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_ARD_GPIO)) == ADDR_SPACE_ARD_GPIO) begin
-      dev_sel_s1n_29 = 5'd6;
+      dev_sel_s1n_30 = 5'd6;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_PMOD_GPIO)) == ADDR_SPACE_PMOD_GPIO) begin
-      dev_sel_s1n_29 = 5'd7;
+      dev_sel_s1n_30 = 5'd7;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_RGBLED_CTRL)) == ADDR_SPACE_RGBLED_CTRL) begin
-      dev_sel_s1n_29 = 5'd8;
+      dev_sel_s1n_30 = 5'd8;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_HW_REV)) == ADDR_SPACE_HW_REV) begin
-      dev_sel_s1n_29 = 5'd9;
+      dev_sel_s1n_30 = 5'd9;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
+                  ~(ADDR_MASK_XADC)) == ADDR_SPACE_XADC) begin
+      dev_sel_s1n_30 = 5'd10;
+
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_TIMER)) == ADDR_SPACE_TIMER) begin
-      dev_sel_s1n_29 = 5'd10;
+      dev_sel_s1n_30 = 5'd11;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_UART0)) == ADDR_SPACE_UART0) begin
-      dev_sel_s1n_29 = 5'd11;
+      dev_sel_s1n_30 = 5'd12;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_UART1)) == ADDR_SPACE_UART1) begin
-      dev_sel_s1n_29 = 5'd12;
+      dev_sel_s1n_30 = 5'd13;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_UART2)) == ADDR_SPACE_UART2) begin
-      dev_sel_s1n_29 = 5'd13;
+      dev_sel_s1n_30 = 5'd14;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_UART3)) == ADDR_SPACE_UART3) begin
-      dev_sel_s1n_29 = 5'd14;
+      dev_sel_s1n_30 = 5'd15;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_UART4)) == ADDR_SPACE_UART4) begin
-      dev_sel_s1n_29 = 5'd15;
+      dev_sel_s1n_30 = 5'd16;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_I2C0)) == ADDR_SPACE_I2C0) begin
-      dev_sel_s1n_29 = 5'd16;
+      dev_sel_s1n_30 = 5'd17;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_I2C1)) == ADDR_SPACE_I2C1) begin
-      dev_sel_s1n_29 = 5'd17;
+      dev_sel_s1n_30 = 5'd18;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_SPI_FLASH)) == ADDR_SPACE_SPI_FLASH) begin
-      dev_sel_s1n_29 = 5'd18;
+      dev_sel_s1n_30 = 5'd19;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_SPI_LCD)) == ADDR_SPACE_SPI_LCD) begin
-      dev_sel_s1n_29 = 5'd19;
+      dev_sel_s1n_30 = 5'd20;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_SPI_ETH)) == ADDR_SPACE_SPI_ETH) begin
-      dev_sel_s1n_29 = 5'd20;
+      dev_sel_s1n_30 = 5'd21;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_SPI_RP0)) == ADDR_SPACE_SPI_RP0) begin
-      dev_sel_s1n_29 = 5'd21;
+      dev_sel_s1n_30 = 5'd22;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_SPI_RP1)) == ADDR_SPACE_SPI_RP1) begin
-      dev_sel_s1n_29 = 5'd22;
+      dev_sel_s1n_30 = 5'd23;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_SPI_ARD)) == ADDR_SPACE_SPI_ARD) begin
-      dev_sel_s1n_29 = 5'd23;
+      dev_sel_s1n_30 = 5'd24;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_SPI_MKR)) == ADDR_SPACE_SPI_MKR) begin
-      dev_sel_s1n_29 = 5'd24;
+      dev_sel_s1n_30 = 5'd25;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_USBDEV)) == ADDR_SPACE_USBDEV) begin
-      dev_sel_s1n_29 = 5'd25;
+      dev_sel_s1n_30 = 5'd26;
 
-    end else if ((tl_s1n_29_us_h2d.a_address &
+    end else if ((tl_s1n_30_us_h2d.a_address &
                   ~(ADDR_MASK_RV_PLIC)) == ADDR_SPACE_RV_PLIC) begin
-      dev_sel_s1n_29 = 5'd26;
+      dev_sel_s1n_30 = 5'd27;
 end
   end
 
@@ -355,17 +365,17 @@ end
   tlul_socket_1n #(
     .HReqDepth (4'h0),
     .HRspDepth (4'h0),
-    .DReqDepth (108'h0),
-    .DRspDepth (108'h0),
-    .N         (27)
-  ) u_s1n_29 (
+    .DReqDepth (112'h0),
+    .DRspDepth (112'h0),
+    .N         (28)
+  ) u_s1n_30 (
     .clk_i        (clk_sys_i),
     .rst_ni       (rst_sys_ni),
-    .tl_h_i       (tl_s1n_29_us_h2d),
-    .tl_h_o       (tl_s1n_29_us_d2h),
-    .tl_d_o       (tl_s1n_29_ds_h2d),
-    .tl_d_i       (tl_s1n_29_ds_d2h),
-    .dev_select_i (dev_sel_s1n_29)
+    .tl_h_i       (tl_s1n_30_us_h2d),
+    .tl_h_o       (tl_s1n_30_us_d2h),
+    .tl_d_o       (tl_s1n_30_ds_h2d),
+    .tl_d_i       (tl_s1n_30_ds_d2h),
+    .dev_select_i (dev_sel_s1n_30)
   );
   tlul_socket_m1 #(
     .HReqDepth (8'h0),
@@ -373,26 +383,26 @@ end
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (2)
-  ) u_sm1_30 (
+  ) u_sm1_31 (
     .clk_i        (clk_sys_i),
     .rst_ni       (rst_sys_ni),
-    .tl_h_i       (tl_sm1_30_us_h2d),
-    .tl_h_o       (tl_sm1_30_us_d2h),
-    .tl_d_o       (tl_sm1_30_ds_h2d),
-    .tl_d_i       (tl_sm1_30_ds_d2h)
+    .tl_h_i       (tl_sm1_31_us_h2d),
+    .tl_h_o       (tl_sm1_31_us_d2h),
+    .tl_d_o       (tl_sm1_31_ds_h2d),
+    .tl_d_i       (tl_sm1_31_ds_d2h)
   );
   tlul_fifo_async #(
     .ReqDepth        (1),
     .RspDepth        (1)
-  ) u_asf_31 (
+  ) u_asf_32 (
     .clk_h_i      (clk_sys_i),
     .rst_h_ni     (rst_sys_ni),
     .clk_d_i      (clk_usb_i),
     .rst_d_ni     (rst_usb_ni),
-    .tl_h_i       (tl_asf_31_us_h2d),
-    .tl_h_o       (tl_asf_31_us_d2h),
-    .tl_d_o       (tl_asf_31_ds_h2d),
-    .tl_d_i       (tl_asf_31_ds_d2h)
+    .tl_h_i       (tl_asf_32_us_h2d),
+    .tl_h_o       (tl_asf_32_us_d2h),
+    .tl_d_o       (tl_asf_32_ds_h2d),
+    .tl_d_i       (tl_asf_32_ds_d2h)
   );
 
 endmodule

--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -109,6 +109,13 @@ module top_sonata (
   input  logic       ah_tmpio12, // CIPO
   output logic       ah_tmpio13, // SCLK
 
+  // Arduino shield analog(ue) pins digital inputs
+  input logic [5:0]  ard_an_di,
+
+  // Arduino shield analog(ue) pins actual analog(ue) input pairs
+  input wire  [5:0]  ard_an_p,
+  input wire  [5:0]  ard_an_n,
+
   // mikroBUS Click other
   output logic       mb10, // PWM
   input  logic       mb9,  // Interrupt
@@ -381,6 +388,11 @@ module top_sonata (
     // PMOD GPIO
     .pmod_gp_i      ({pmod1, pmod0}),
     .pmod_gp_o       ({pmod_gp_oe, pmod_gp_o}),
+
+    // Arduino Shield Analog(ue)
+    .ard_an_di_i    (ard_an_di),
+    .ard_an_p_i     (ard_an_p),
+    .ard_an_n_i     (ard_an_n),
 
     // UART 0
     .uart0_rx_i     (ser0_rx),

--- a/rtl/ip/xadc/rtl/xadc.sv
+++ b/rtl/ip/xadc/rtl/xadc.sv
@@ -1,0 +1,164 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module xadc (
+  input clk_i,
+  input rst_ni,
+
+  input  tlul_pkg::tl_h2d_t tl_i,
+  output tlul_pkg::tl_d2h_t tl_o,
+
+  // Analog(ue) input width not parametrised due to PCB-specific
+  // mapping to XADC pins (see u_xadc below).
+  input wire [5:0] analog_p_i,
+  input wire [5:0] analog_n_i
+);
+
+  // TLUL parameters
+  // Specify the 4-byte address width required to cover the whole of the
+  // address space assigned to the XADC in the TLUL crossbar.
+  // That way, `xadc_adapter` is not susceptible to aliasing.
+  localparam int TAW = 10;
+  localparam int TDW = 32;
+
+  // DRP 'parameters' (fixed by XADC Hard-IP) to aid readability
+  localparam int XAW = 7;
+  localparam int XDW = 16;
+
+  logic           drp_dclk;
+  logic           drp_den;
+  logic           drp_dwe;
+  logic [XAW-1:0] drp_daddr;
+  logic [XDW-1:0] drp_di;
+  logic           drp_drdy;
+  logic [XDW-1:0] drp_do;
+
+  // TLUL to DRP adaptor specifically for XADC
+  xadc_adapter #(
+    .TAw(TAW),
+    .TDw(TDW),
+    .XAw(XAW),
+    .XDw(XDW)
+  ) u_xadc_adapter (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+
+    .tl_i        (tl_i),
+    .tl_o        (tl_o),
+
+    .drp_dclk_o  (drp_dclk),
+    .drp_den_o   (drp_den),
+    .drp_dwe_o   (drp_dwe),
+    .drp_daddr_o (drp_daddr),
+    .drp_di_o    (drp_di),
+    .drp_drdy_i  (drp_drdy),
+    .drp_do_i    (drp_do)
+  );
+
+`ifndef SYNTHESIS
+  // Fake XADC - responds with the number of requests submitted
+
+  // Respond the cycle after a request
+  // TODO: randomise response delay for better bug-finding
+  logic respond_d;
+  logic respond_q;
+  assign respond_d = drp_den;
+  always_ff @(posedge drp_dclk or negedge rst_ni) begin
+    if (!rst_ni) begin
+      respond_q <= '0;
+    end else begin
+      respond_q <= respond_d;
+    end
+  end
+
+  // Increment counter when get a request, and use count as response data
+  logic [XDW-1:0] req_count_d;
+  logic [XDW-1:0] req_count_q;
+  assign req_count_d = drp_den ? req_count_q + '1 : req_count_q;
+  always @(posedge drp_dclk, negedge rst_ni) begin
+    if (!rst_ni) begin
+      req_count_q <= '0;
+    end else begin
+      req_count_q <= req_count_d;
+    end
+  end
+
+  // Provide signals to the TLUL-DRP adapter
+  assign drp_drdy = respond_q;
+  assign drp_do = req_count_q;
+
+  // Unused signals from TLUL adapter
+  logic unused_drp_dwe, unused_drp_daddr, unused_drp_di;
+  assign unused_drp_dwe   =  drp_dwe;
+  assign unused_drp_daddr = ^drp_daddr;
+  assign unused_drp_di    = ^drp_di;
+
+  // Unused analog(ue) input signals
+  logic unused_analog_p, unused_analog_n;
+  assign unused_analog_p  = ^analog_p_i;
+  assign unused_analog_n  = ^analog_n_i;
+
+`else  // SYNTHESIS
+  // Real XADC
+  xadc_wiz_0 u_xadc (
+    .reset_in            (0), // Reset signal for the System Monitor control logic
+
+    .dclk_in             (drp_dclk), // Clock input for the dynamic reconfiguration port
+    .den_in              (drp_den), // Enable Signal for the dynamic reconfiguration port
+    .dwe_in              (drp_dwe), // Write Enable for the dynamic reconfiguration port
+    .daddr_in            (drp_daddr), // Address bus for the dynamic reconfiguration port
+    .di_in               (drp_di), // Input data bus for the dynamic reconfiguration port
+    .drdy_out            (drp_drdy), // Data ready signal for the dynamic reconfiguration port
+    .do_out              (drp_do), // Output data bus for dynamic reconfiguration port
+
+    .busy_out            (), // ADC Busy signal
+    .channel_out         (), // Channel Selection Outputs
+    .eoc_out             (), // End of Conversion Signal
+    .eos_out             (), // End of Sequence Signal
+    .ot_out              (), // Over-Temperature alarm output
+    .vccaux_alarm_out    (), // VCCAUX-sensor alarm output
+    .vccint_alarm_out    (), // VCCINT-sensor alarm output
+    .user_temp_alarm_out (), // Temperature-sensor alarm output
+    .vbram_alarm_out     (),
+    .alarm_out           (), // OR'ed output of all the Alarms
+
+    .vp_in               (0), // Dedicated Analog Input Pair
+    .vn_in               (0),
+//  .vauxp0              (0), // Auxiliary channel 0
+//  .vauxn0              (0),
+//  .vauxp1              (0), // Auxiliary channel 1
+//  .vauxn1              (0),
+//  .vauxp2              (0), // Auxiliary channel 2
+//  .vauxn2              (0),
+//  .vauxp3              (0), // Auxiliary channel 3
+//  .vauxn3              (0),
+    .vauxp4              (analog_p_i[0]), // Auxiliary channel 4
+    .vauxn4              (analog_n_i[0]),
+    .vauxp5              (analog_p_i[2]), // Auxiliary channel 5
+    .vauxn5              (analog_n_i[2]),
+    .vauxp6              (analog_p_i[4]), // Auxiliary channel 6
+    .vauxn6              (analog_n_i[4]),
+//  .vauxp7              (0), // Auxiliary channel 7
+//  .vauxn7              (0),
+//  .vauxp8              (0), // Auxiliary channel 8
+//  .vauxn8              (0),
+//  .vauxp9              (0), // Auxiliary channel 9
+//  .vauxn9              (0),
+//  .vauxp10             (0), // Auxiliary channel 10
+//  .vauxn10             (0),
+//  .vauxp11             (0), // Auxiliary channel 11
+//  .vauxn11             (0),
+    .vauxp12             (analog_p_i[1]), // Auxiliary channel 12
+    .vauxn12             (analog_n_i[1]),
+    .vauxp13             (analog_p_i[3]), // Auxiliary channel 13
+    .vauxn13             (analog_n_i[3]),
+    .vauxp14             (analog_p_i[5]), // Auxiliary channel 14
+    .vauxn14             (analog_n_i[5])
+//  .vauxp15             (0), // Auxiliary channel 15
+//  .vauxn15             (0)
+  );
+
+`endif  // SYNTHESIS
+
+endmodule

--- a/rtl/ip/xadc/rtl/xadc_adapter.sv
+++ b/rtl/ip/xadc/rtl/xadc_adapter.sv
@@ -1,0 +1,155 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module xadc_adapter #(
+  parameter int TAw = 10, // Width of TLUL address to expose
+  parameter int TDw = 32, // Shall be matched with TL_DW
+  parameter int XAw = 7,  // XADC DRP address width (for readability)
+  parameter int XDw = 16  // XADC DRP data width (for readability)
+) (
+  input clk_i,
+  input rst_ni,
+
+  input  tlul_pkg::tl_h2d_t tl_i,
+  output tlul_pkg::tl_d2h_t tl_o,
+
+  output           drp_dclk_o,
+  output           drp_den_o,
+  output           drp_dwe_o,
+  output [XAw-1:0] drp_daddr_o,
+  output [XDw-1:0] drp_di_o,
+  input            drp_drdy_i,
+  input  [XDw-1:0] drp_do_i
+);
+
+  // Signals to-from the SRAM interface of TLUL adapter
+  logic           mem_req;
+  logic           mem_gnt;
+  logic           mem_we;
+  logic [TAw-1:0] mem_addr;  // in bus words.
+  logic [TDw-1:0] mem_wmask;
+  logic [TDw-1:0] mem_wdata;
+  logic           mem_rvalid;
+  logic [TDw-1:0] mem_rdata;
+  logic     [1:0] mem_rerror;
+
+  // TLUL to SRAM adapter.
+  // We can use the SRAM interface as an approximation of a DRP interface,
+  // with a few tweaks.
+  tlul_adapter_sram #(
+    .SramAw(TAw),
+    .SramDw(TDw),
+    .Outstanding(1),
+    .ByteAccess(0),
+    .ErrOnWrite(0),
+    .ErrOnRead(0),
+    .CmdIntgCheck(0),
+    .EnableRspIntgGen(1),
+    .EnableDataIntgGen(0),
+    .EnableDataIntgPt(0),
+    .SecFifoPtr(0)
+  ) u_tlul_adapter (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+
+    .tl_i        (tl_i),
+    .tl_o        (tl_o),
+
+    .en_ifetch_i (prim_mubi_pkg::MuBi4False),
+
+    .req_o       (mem_req),
+    .req_type_o  (),
+    .gnt_i       (mem_gnt),
+    .we_o        (mem_we),
+    .addr_o      (mem_addr),
+    .wdata_o     (mem_wdata),
+    .wdata_cap_o (),
+    .wmask_o     (mem_wmask),
+    .intg_error_o(),
+    .rdata_i     (mem_rdata),
+    .rdata_cap_i (1'b0),
+    .rvalid_i    (mem_rvalid),
+    .rerror_i    (mem_rerror)
+  );
+
+  // Use the supplied clock as the XADC DCLK.
+  // This is divided internally to generate ADCCLK.
+  assign drp_dclk_o = clk_i;
+
+  assign drp_dwe_o = mem_we;
+
+  // Conversion from TLUL byte addresses to DRP register addresses
+  // is done in tlul_adapter_sram.
+  assign drp_daddr_o = mem_addr[XAw-1:0];
+
+  // Use only the bottom 16 bits of write data
+  assign drp_di_o = mem_wdata[XDw-1:0];
+  logic unused_wdata_bits;
+  assign unused_wdata_bits = ^mem_wdata[TDw-1:XDw];
+
+  // The DRP interface can process only one request at a time and can take
+  // some cycles to fulfil a request. So we need to track whether we have
+  // an outstanding read/write request the DRP is still working on.
+  logic drp_busy_d;
+  logic drp_busy_q;
+  assign drp_busy_d = drp_den_o || (drp_busy_q && ~drp_drdy_i);
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      drp_busy_q <= '0;
+    end else begin
+      drp_busy_q <= drp_busy_d;
+    end
+  end
+
+  // General request issue detection
+  logic above_addr_range;
+  // All accesses should be to an address offset inside the
+  // range of the 128 (0-127) XADC DRP registers.
+  assign above_addr_range = |mem_addr[TAw-1:XAw];
+
+  // Write-specific request issue detection
+  logic wmask_bad, wr_to_rd_only_addr;
+  logic unused_wmask_bits;
+  // Writes should include the lower 16-bits,
+  // as the underlying XDC registers are all 16-bit registers.
+  assign wmask_bad = mem_we && ~&mem_wmask[XDw-1:0];
+  assign unused_wmask_bits = ^mem_wmask[TDw-1:XDw];
+  // Writes should be to an address offset inside the writable range.
+  assign wr_to_rd_only_addr = mem_we && ~drp_daddr_o[XAw-1];
+
+  // We have no way to reject bad requests, so we 'accept' and then drop them.
+  // Read requests we can later respond to with an error,
+  // but bad write requests we have to drop silently.
+  logic drop_req;
+  assign drop_req = above_addr_range || wmask_bad || wr_to_rd_only_addr;
+  // Grant host requests if the DRP is ready or we are just going to drop it.
+  assign mem_gnt = mem_req && (~drp_busy_q || drop_req);
+
+  // Only pass valid requests through to the DRP
+  assign drp_den_o = mem_gnt && ~drop_req;
+
+  // Break the return path timing by reporting bad read requests
+  // the clock cycle *after* the request was 'granted'.
+  logic rd_err_d;
+  logic rd_err_q;
+  assign rd_err_d = mem_gnt && ~mem_we && drop_req;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rd_err_q <= '0;
+    end else begin
+      rd_err_q <= rd_err_d;
+    end
+  end
+
+  assign mem_rvalid = drp_drdy_i || rd_err_q;
+
+  assign mem_rerror[0] = 1'b0; // uninteresting "correctable error" bit
+  assign mem_rerror[1] = rd_err_q; // "uncorrectable error" bit
+
+  // The host should know better than to use rdata if rerror[1] is set,
+  // but set rdata to a memorable 'error' value just in case.
+  assign mem_rdata = mem_rerror[1] ? 'hDEADBEEF : {{(TDw-XDw){1'b0}},drp_do_i};
+
+
+endmodule

--- a/rtl/ip/xadc/rtl/xadc_wiz_0.v
+++ b/rtl/ip/xadc/rtl/xadc_wiz_0.v
@@ -1,0 +1,232 @@
+
+// file: xadc_wiz_0.v
+// (c) Copyright 2009 - 2013 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+`timescale 1ns / 1 ps
+
+(* CORE_GENERATION_INFO = "xadc_wiz_0,xadc_wiz_v3_3_8,{component_name=xadc_wiz_0,enable_axi=false,enable_axi4stream=false,dclk_frequency=30,enable_busy=true,enable_convst=false,enable_convstclk=false,enable_dclk=true,enable_drp=true,enable_eoc=true,enable_eos=true,enable_vbram_alaram=true,enable_vccddro_alaram=false,enable_Vccint_Alaram=true,enable_Vccaux_alaram=true,enable_vccpaux_alaram=false,enable_vccpint_alaram=false,ot_alaram=true,user_temp_alaram=true,timing_mode=continuous,channel_averaging=None,sequencer_mode=on,startup_channel_selection=independent_adc}" *)
+
+
+module xadc_wiz_0
+          (
+          daddr_in,            // Address bus for the dynamic reconfiguration port
+          dclk_in,             // Clock input for the dynamic reconfiguration port
+          den_in,              // Enable Signal for the dynamic reconfiguration port
+          di_in,               // Input data bus for the dynamic reconfiguration port
+          dwe_in,              // Write Enable for the dynamic reconfiguration port
+          reset_in,            // Reset signal for the System Monitor control logic
+          vauxp4,              // Auxiliary channel 4
+          vauxn4,
+          vauxp5,              // Auxiliary channel 5
+          vauxn5,
+          vauxp6,              // Auxiliary channel 6
+          vauxn6,
+          vauxp12,             // Auxiliary channel 12
+          vauxn12,
+          vauxp13,             // Auxiliary channel 13
+          vauxn13,
+          vauxp14,             // Auxiliary channel 14
+          vauxn14,
+          busy_out,            // ADC Busy signal
+          channel_out,         // Channel Selection Outputs
+          do_out,              // Output data bus for dynamic reconfiguration port
+          drdy_out,            // Data ready signal for the dynamic reconfiguration port
+          eoc_out,             // End of Conversion Signal
+          eos_out,             // End of Sequence Signal
+          ot_out,              // Over-Temperature alarm output
+          vccaux_alarm_out,    // VCCAUX-sensor alarm output
+          vccint_alarm_out,    //  VCCINT-sensor alarm output
+          user_temp_alarm_out, // Temperature-sensor alarm output
+          vbram_alarm_out,
+          alarm_out,           // OR'ed output of all the Alarms
+          vp_in,               // Dedicated Analog Input Pair
+          vn_in);
+
+          input [6:0] daddr_in;
+          input dclk_in;
+          input den_in;
+          input [15:0] di_in;
+          input dwe_in;
+          input reset_in;
+          input vauxp4;
+          input vauxn4;
+          input vauxp5;
+          input vauxn5;
+          input vauxp6;
+          input vauxn6;
+          input vauxp12;
+          input vauxn12;
+          input vauxp13;
+          input vauxn13;
+          input vauxp14;
+          input vauxn14;
+          input vp_in;
+          input vn_in;
+
+          output busy_out;
+          output [4:0] channel_out;
+          output [15:0] do_out;
+          output drdy_out;
+          output eoc_out;
+          output eos_out;
+          output ot_out;
+          output vccaux_alarm_out;
+          output vccint_alarm_out;
+          output user_temp_alarm_out;
+          output vbram_alarm_out;
+          output alarm_out;
+
+          wire GND_BIT;
+          assign GND_BIT = 0;
+          wire [15:0] aux_channel_p;
+          wire [15:0] aux_channel_n;
+          wire [7:0]  alm_int;
+          assign alarm_out = alm_int[7];
+          assign vbram_alarm_out = alm_int[3];
+          assign vccaux_alarm_out = alm_int[2];
+          assign vccint_alarm_out = alm_int[1];
+          assign user_temp_alarm_out = alm_int[0];
+          assign aux_channel_p[0] = 1'b0;
+          assign aux_channel_n[0] = 1'b0;
+
+          assign aux_channel_p[1] = 1'b0;
+          assign aux_channel_n[1] = 1'b0;
+
+          assign aux_channel_p[2] = 1'b0;
+          assign aux_channel_n[2] = 1'b0;
+
+          assign aux_channel_p[3] = 1'b0;
+          assign aux_channel_n[3] = 1'b0;
+
+          assign aux_channel_p[4] = vauxp4;
+          assign aux_channel_n[4] = vauxn4;
+
+          assign aux_channel_p[5] = vauxp5;
+          assign aux_channel_n[5] = vauxn5;
+
+          assign aux_channel_p[6] = vauxp6;
+          assign aux_channel_n[6] = vauxn6;
+
+          assign aux_channel_p[7] = 1'b0;
+          assign aux_channel_n[7] = 1'b0;
+
+          assign aux_channel_p[8] = 1'b0;
+          assign aux_channel_n[8] = 1'b0;
+
+          assign aux_channel_p[9] = 1'b0;
+          assign aux_channel_n[9] = 1'b0;
+
+          assign aux_channel_p[10] = 1'b0;
+          assign aux_channel_n[10] = 1'b0;
+
+          assign aux_channel_p[11] = 1'b0;
+          assign aux_channel_n[11] = 1'b0;
+
+          assign aux_channel_p[12] = vauxp12;
+          assign aux_channel_n[12] = vauxn12;
+
+          assign aux_channel_p[13] = vauxp13;
+          assign aux_channel_n[13] = vauxn13;
+
+          assign aux_channel_p[14] = vauxp14;
+          assign aux_channel_n[14] = vauxn14;
+
+          assign aux_channel_p[15] = 1'b0;
+          assign aux_channel_n[15] = 1'b0;
+XADC #(
+        .INIT_40(16'h0000), // config reg 0
+        .INIT_41(16'h8000), // config reg 1
+        .INIT_42(16'h1400), // config reg 2
+        .INIT_48(16'h0000), // Sequencer channel selection
+        .INIT_49(16'h7070), // Sequencer channel selection
+        .INIT_4A(16'h0000), // Sequencer Average selection
+        .INIT_4B(16'h0000), // Sequencer Average selection
+        .INIT_4C(16'h0000), // Sequencer Bipolar selection
+        .INIT_4D(16'h0000), // Sequencer Bipolar selection
+        .INIT_4E(16'h0000), // Sequencer Acq time selection
+        .INIT_4F(16'h0000), // Sequencer Acq time selection
+        .INIT_50(16'hB5ED), // Temp alarm trigger
+        .INIT_51(16'h57E4), // Vccint upper alarm limit
+        .INIT_52(16'hA147), // Vccaux upper alarm limit
+        .INIT_53(16'hCA33),  // Temp alarm OT upper
+        .INIT_54(16'hA93A), // Temp alarm reset
+        .INIT_55(16'h52C6), // Vccint lower alarm limit
+        .INIT_56(16'h9555), // Vccaux lower alarm limit
+        .INIT_57(16'hAE4E),  // Temp alarm OT reset
+        .INIT_58(16'h5999), // VCCBRAM upper alarm limit
+        .INIT_5C(16'h5111),  //  VCCBRAM lower alarm limit
+        .SIM_DEVICE("7SERIES"),
+        .SIM_MONITOR_FILE("design.txt")
+)
+
+inst (
+        .CONVST(GND_BIT),
+        .CONVSTCLK(GND_BIT),
+        .DADDR(daddr_in[6:0]),
+        .DCLK(dclk_in),
+        .DEN(den_in),
+        .DI(di_in[15:0]),
+        .DWE(dwe_in),
+        .RESET(reset_in),
+        .VAUXN(aux_channel_n[15:0]),
+        .VAUXP(aux_channel_p[15:0]),
+        .ALM(alm_int),
+        .BUSY(busy_out),
+        .CHANNEL(channel_out[4:0]),
+        .DO(do_out[15:0]),
+        .DRDY(drdy_out),
+        .EOC(eoc_out),
+        .EOS(eos_out),
+        .JTAGBUSY(),
+        .JTAGLOCKED(),
+        .JTAGMODIFIED(),
+        .OT(ot_out),
+        .MUXADDR(),
+        .VP(vp_in),
+        .VN(vn_in)
+          );
+
+endmodule

--- a/rtl/ip/xadc/xadc.core
+++ b/rtl/ip/xadc/xadc.core
@@ -1,0 +1,38 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:xadc:0.1"
+description: "xadc"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:constants:top_pkg
+      - lowrisc:prim:all
+    files:
+      - rtl/xadc.sv
+      - rtl/xadc_adapter.sv
+      - rtl/xadc_wiz_0.v
+    file_type: systemVerilogSource
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+targets:
+  default: &default_target
+    filesets:
+      - files_rtl
+    toplevel: xadc
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"

--- a/sonata_system.core
+++ b/sonata_system.core
@@ -17,6 +17,7 @@ filesets:
       - lowrisc:ip:spi
       - lowrisc:ip:rgbled_ctrl
       - lowrisc:ip:hyperram
+      - lowrisc:ip:xadc
       - lowrisc:opentitan:top_earlgrey_rv_plic
       - lowrisc:tlul:adapter_host
       - lowrisc:tlul:adapter_reg


### PR DESCRIPTION
Add a generated wrapper for the XADC built-in to the FPGA and an adapter to connect it to the TLUL crossbar
via the XADC's Dynamic Reconfiguration Port (DRP).

The DRP registers are all 16-bits, and have been mapped at 32-bit intervals in the TLUL address space.
All writes must be 16-bit writes or they will be silently dropped. Any writes outside of the range of writable registers will be silently dropped.
Any reads above the range of DRP registers will cause an error.

Driver being worked on by @AlexJones0 