### PR TITLE
[doc] Update getting started docs for latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Sonata is part of the [Sunburst Project](https://www.sunburst-project.org) funde
 
 ## Current status
 
-We are delighted to announce the first release of the Sonata system!
-It is available now from GitHub [here][release-v0.2].
+We are delighted to announce the release of the Sonata system!
+The latest release is available now from GitHub [here][release-v0.3].
 
 This new release provides a base FPGA image with I2C/SPI/UART peripherals that are suitable for use with the expansion headers as well as the on-board hardware.
 Please note that full ethernet support will still be pending software work and not available in this first release.
@@ -24,7 +24,7 @@ Environment setup and build instructions are available for Windows, macOS and Li
 If you find any issues with the Sonata system, or have features you would like to propose, please create an issue on GitHub.
 For support with the board itself please use the [forum][newae-forum] on the NewAE website, create an issue at <https://github.com/newaetech/sonata-pcb>, or reach out to NewAE directly.
 
-[release-v0.2]: https://github.com/lowRISC/sonata-system/releases/tag/v0.2
+[release-v0.3]: https://github.com/lowRISC/sonata-system/releases/tag/v0.3
 [newae-forum]: https://forum.newae.com/c/sonata-board/15
 
 ## Getting Started

--- a/doc/guide/building-examples.md
+++ b/doc/guide/building-examples.md
@@ -5,15 +5,15 @@ Once you've got these builds working, you can easily add more features to the ex
 
 ## Using our template
 
-Please go to the [Sonata software repository](https://github.com/lowRISC/sonata-software) and build a full application from there.
+Please go to the [Sonata software repository](https://github.com/lowRISC/sonata-software) using the branch appropriate to your release (e.g. checkout the ['v0.3' branch](https://github.com/lowRISC/sonata-software/tree/v0.3)) and build a full application from there.
 Inside your setup you should simply be able to build it like this:
 
 ```sh
-git clone --recurse-submodule \
+git clone --recurse-submodule -b v0.3 \
     https://github.com/lowRISC/sonata-software.git
 cd sonata-software
-xmake config --board=sonata
-xmake build
+nix develop .
+xmake -P examples/
 ```
 
 After running this you should see the build run to completion and report success, the critical lines indicating a successful build are (note output size may differ):
@@ -30,12 +30,12 @@ You can drag and drop this UF2 file into the `SONATA` drive to program the firmw
 
 On Linux use the following command to check you can receive serial output:
 ```sh
-screen /dev/ttyUSB2 921600
+screen /dev/ttyUSB2 115200
 ```
 
 On Mac this is similar
 ```sh
-screen /dev/tty.usbserial-LN100302 921600
+screen /dev/tty.usbserial-LN100302 115200
 ```
 
 On Windows, connecting to serial ports directly from within WSL2 (default) is not possible.
@@ -44,6 +44,8 @@ Alternatively you can use [Termite](https://www.compuphase.com/software_termite.
 
 Select "Serial" as "Connection type", put the COM port in the "Serial line" text field, and set "Speed" to 921600.
 To find out what serial ports are available, you can open Device Manager and all connected serial ports are listed under "Ports (COM & LPT)" section.
+
+Note that the baremetal examples below use a higher baud rate, 921600, use that in place of 115200 when running the baremetal examples.
 
 ## Baremetal examples
 

--- a/doc/guide/fpga-update.md
+++ b/doc/guide/fpga-update.md
@@ -1,10 +1,5 @@
 # Reloading the FPGA Image
 
-*We have seen some issues with the standard FPGA loading flow using the RP2040.
-Until these are fixed we recommend using a special version of the RP2040 firmware that has the FPGA's bitstream pre-built into it.
-This is named `tmp_rpi_rp2_part1_v0.2.uf2` in the [current release](https://github.com/lowRISC/sonata-system/releases/tag/v0.2).
-When using that firmware you do not need to follow the instructions below.*
-
 The first thing you should do before building the firmware is to get the latest version of the FPGA image, called the "bitstream". This contains the configuration
 for the microcontroller core & peripherals. The "release version" of the bitstream *must* match the
 configuration you use to build the software, as if the bitstream is a different version than what
@@ -15,16 +10,18 @@ software setup.
 
 While you can build your own bitstream as described
 in [FPGA Development](../dev/fpga-development.md), we recommend starting with our prebuilt bitstream first. Building the bitstream requires
-installing Vivado which takes a large amount of hard drive space and requires a seperate manual installation process (as well as the build
+installing Vivado which takes a large amount of hard drive space and requires a separate manual installation process (as well as the build
 process is much slower than a software compile, so adds delay until you can play with CHERIoT).
 
 ## Selecting a Bitstream
 
 When the Sonata board is plugged in, it loads one of three bitstreams. This is selected by the switch below the USB port labeled `Bitstream`:
-
 ![](img/sonata-selectbs.jpeg)
 
-The LEDs besides the switch show the current image selected as well for confirmation. We recommend using Slot 2 (the middle setting), leaving Slot 1 as the test image we shipped.
+The LEDs besides the switch show the current image selected as well for confirmation.
+
+The slot used by a bitstream is selected by the uf2 file.
+The bitstream uf2 provided in the release uses Slot 1.
 
 In case you have trouble with the board, you can quickly switch to Slot 1 to confirm the LCD, LEDs, and similar are all functioning correctly. However there is no problem
 to overwrite any of the slots, the default image can easily be copied back if you want later.
@@ -34,9 +31,9 @@ to overwrite any of the slots, the default image can easily be copied back if yo
 To program the Sonata bitstream:
 
 1. Download the bitstream from [our releases](https://github.com/lowRISC/sonata-system/releases)
-2. Select slot 2 using switch SW3 (`Bitstream`)
-3. Plug in Sonata board. You should see a SONATA drive (see troubleshooting section if unsure).
-4. Drag the updated `.bit` file and wait for the copy to complete (on Linux note the copy command may return immediately, so you need to wait until it's done.)
+2. Make sure that you have the bitstream switch (SW3) set to 1.
+3. Plug in your Sonata board using the main USB. You should see a `SONATA` drive (see troubleshooting section if unsure).
+4. Copy the updated FPGA `sonata-vX.Y.bit.slot1.uf2` file to the drive and wait for the copy to complete (on Linux note the copy command may return immediately, so you need to wait until it's done.)
 5. The board should automatically restart once the image is copied over. You should see the `FPGA Config` LED come on:
 
 ![](img/sonata-fpgaconfig.jpeg)
@@ -50,8 +47,8 @@ This indicates the FPGA configuration succeeded. This LED should stay on. You sh
 Here is the commands you'd need to do all of that, assuming Sonata was already plugged in and has been mounted at `/media/sonata`
 
 ```sh
-wget THEBESTURL.COM/lowrisc_sonata_system_0.bit
-cp lowrisc_sonata_system_0.bit /media/sonata/.
+wget https://github.com/lowRISC/sonata-system/releases/download/v0.3/sonata-v0.3.bit.slot1.uf2
+cp sonata-v0.3.bit.slot1.uf2 /media/sonata/
 ```
 
 Many Linux desktop distributions will automount if you open the drive via the graphical interface, so you may find it easier to do this from your Linux desktop,
@@ -80,12 +77,15 @@ be because the `RPI Boot` button was held down when plugging in the board.
 The Sonata board will print status and messages to the `LOG.TXT` which can be helpful for debugging. It should show the status of valid-looking bitstreams:
 
 ```
-CRIT: FW_VER 0.1.2
-INFO: No bitstream in slot 0
-INFO: No bitstream in slot 1
-INFO: No bitstream in slot 2
-INFO: Using slot 2
-INFO: No bitstream in flash @ 1400000
+TEST CRC Test PASS
+CRIT: FW_VER 0.4.0
+INFO: Bitstream found in slot 0
+INFO: Bitstream found in slot 1
+INFO: Bitstream found in slot 2
+INFO: Firmware found in slot 0
+INFO: No firmware in slot 1
+INFO: No firmware in slot 2
+INFO: Using slot 0
 ```
 
 ### FPGA Config Led not coming on

--- a/doc/guide/rp2040-update.md
+++ b/doc/guide/rp2040-update.md
@@ -1,10 +1,5 @@
 # Reloading the RP2040 USB Controller
 
-*We have seen some issues with the standard FPGA loading flow using the RP2040.
-Until these are fixed we recommend using a special version of the RP2040 firmware that has the FPGA's bitstream pre-built into it.
-This is named `tmp_rpi_rp2_part1_v0.2.uf2` in the [current release](https://github.com/lowRISC/sonata-system/releases/tag/v0.2).
-This will be used in place of the `rpi_rp2_v0.X.uf2` file referred to below.*
-
 Before plugging in your Sonata board, hold down the SW9 labelled "RP2040 Boot", and while holding this button plug your board into your laptop using the Main USB.
 
 A drive called RPI-RP2 should pop up on your computer and drag `rpi_rp2_v0.X.uf2` into it.


### PR DESCRIPTION
Updated the docs linked from getting started to match what's needed for the v0.3 release, note the downgrade on the baud rate (things built with sonata-software are still running on 115200).

I'd appreciate a rapid review on this, the prior v0.2 release was effectively broken because the latest main of sonata-software wouldn't build binaries compatible with it (due to the switch to writing .elf directly to flash). We've got a new (working) v0.3 release done but want to ensure people reading the getting started docs are guided appropriately so they can use it.

There's more doc updates/reviews to do to get everything consistent for v1.0 this is just the critical stuff so the getting started material is consistent with the latest working release.