### PR TITLE
[util] Fix sonata-openocd-cfg.tcl for use with OpenOCD 0.12.0

### DIFF
--- a/util/sonata-openocd-cfg.tcl
+++ b/util/sonata-openocd-cfg.tcl
@@ -21,7 +21,7 @@ target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 
 adapter speed 10000
 
-riscv set_prefer_sba on
+riscv set_mem_access sysbus
 reset_config none
 
 init


### PR DESCRIPTION
The set_prefer_sba command has been deprecated, set_mem_access should be used instead.