### PR TITLE
Update lowrisc_ibex to lowrisc/cheriot-ibex@b4209e3a

### DIFF
--- a/vendor/lowrisc_ibex.lock.hjson
+++ b/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowrisc/cheriot-ibex.git
-    rev: 091ccfc3ce5c9c8dad4acfe200ee45b9401e6a9c
+    rev: b4209e3aaf64061869e0ab8b9616efc151fca4f5
   }
 }

--- a/vendor/lowrisc_ibex/rtl/ibexc_top.sv
+++ b/vendor/lowrisc_ibex/rtl/ibexc_top.sv
@@ -406,7 +406,7 @@ module ibexc_top import ibex_pkg::*; import cheri_pkg::*; #(
     .ic_data_addr_o    (ic_data_addr),
     .ic_data_wdata_o   (ic_data_wdata),
     .ic_data_rdata_i   (ic_data_rdata),
-    .ic_scr_key_valid_i(1'b0)
+    .ic_scr_key_valid_i(1'b1)
   );
 
   assign data_wdata_intg_o = 7'h0;


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowrisc/cheriot-ibex.git to revision b4209e3aaf64061869e0ab8b9616efc151fca4f5

* [rtl] Fix ICache scramble key valid input (Greg Chadwick)