### PR TITLE
Rework CDC primitive constraints

### DIFF
--- a/data/impl_timing.xdc
+++ b/data/impl_timing.xdc
@@ -3,36 +3,3 @@
 ## SPDX-License-Identifier: Apache-2.0
 
 # This file is for timing constraints to be applied *after* synthesis.
-# i.e. timing constraints on internal paths.
-
-set_false_path -from [get_pins -of [get_cells u_sonata_system/g_hyperram.u_hyperram/u_hbmc_tl_top/u_hbmc_cmd_fifo/*storage*/*]]
-set_false_path -from [get_pins -of [get_cells u_sonata_system/g_hyperram.u_hyperram/u_hbmc_tl_top/hbmc_ufifo_inst/u_fifo/*storage*/*]]
-set_false_path -from [get_pins -of [get_cells u_sonata_system/g_hyperram.u_hyperram/u_hbmc_tl_top/hbmc_dfifo_inst/u_fifo/*storage*/*]]
-
-# TODO: Want some general constraints that will setup appropriate false paths
-# for all CDC prims. An attempt is below but it isn't working yet.
-#set sync_cells [get_cells -hier -filter {ORIG_REF_NAME == prim_flop_2sync}]
-#
-#foreach sync_cell $sync_cells {
-#  set sync_pins [get_pins -of [get_cells -hier -regexp $sync_cell/.*u_sync_1.*]]
-#  if {[info exists endpoint_sync_pins_for_false_paths]} {
-#    set endpoint_sync_pins_for_false_paths $sync_pins
-#  } else {
-#    lappend endpoint_sync_pins_for_false_paths $sync_pins
-#  }
-#}
-#
-#set_false_path -to $endpoint_sync_pins_for_false_paths
-#
-#set async_fifo_cells [get_cells -hier -filter {ORIG_REF_NAME == prim_fifo_async}]
-#
-#foreach async_fifo_cell $async_fifo_cells {
-#  set async_fifo_pins [get_pins -of [get_cells -hier -regexp $async_fifo_cell/.*storage.*]]
-#  if {[info exists startpoint_fifo_async_pins_for_false_paths]} {
-#    set startpoint_fifo_async_pins_for_false_paths $async_fifo_pins
-#  } else {
-#    lappend startpoint_fifo_async_pins_for_false_paths $async_fifo_pins
-#  }
-#}
-#
-#set_false_path -from $startpoint_fifo_async_pins_for_false_paths

--- a/data/pins_sonata.xdc
+++ b/data/pins_sonata.xdc
@@ -309,3 +309,8 @@ set_property -dict { PACKAGE_PIN   J2  IOSTANDARD   LVCMOS18 } [get_ports { hype
 set_property CFGBVS VCCO [current_design]
 set_property CONFIG_VOLTAGE 3.3 [current_design]
 set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+
+# Primitives
+set_property DONT_TOUCH TRUE [get_cells -hier -filter {ORIG_REF_NAME == prim_flop_2sync}]
+set_property DONT_TOUCH TRUE [get_cells -hier -filter {ORIG_REF_NAME == prim_fifo_async}]
+set_property DONT_TOUCH TRUE [get_cells -hier -filter {ORIG_REF_NAME == prim_fifo_async_simple}]

--- a/data/synth_timing.xdc
+++ b/data/synth_timing.xdc
@@ -30,3 +30,30 @@ set_false_path -from [get_ports hyperram_dq[*]]
 # False path for 'hb_cs_n' and 'hb_reset_n'
 set_false_path -to [get_ports hyperram_cs]
 set_false_path -to [get_ports hyperram_nrst]
+
+## prim_flop_2sync
+# Set false_path timing exceptions on 2-stage synchroniser inputs.
+# Target the inputs because the flops inside are clocked by the destination.
+#
+# Reliant on the hierarchical pin names of the synchronisers remaining
+# unchanged during synthesis due to use of DONT_TOUCH or KEEP_HIERARCHY.
+set sync_cells [get_cells -hier -filter {ORIG_REF_NAME == prim_flop_2sync}]
+set sync_pins [get_pins -filter {REF_PIN_NAME =~ d_i*} -of $sync_cells]
+# Filter out any that do not have a real timing path (fail to find leaf cell).
+set sync_endpoints [filter [all_fanout -endpoints_only -flat $sync_pins] IS_LEAF]
+set_false_path -to $sync_endpoints
+
+## prim_fifo_async and prim_fifo_async_simple
+# Set false_path timing exceptions on asynchronous fifo outputs.
+# Target the outputs because the storage elements are clocked by the source
+# clock domain (but made safe to read from the destination clock domain
+# thanks to the gray-coded read/write pointers and surrounding logic).
+#
+# Reliant on the hierarchical pin names of the async fifos remaining
+# unchanged during synthesis due to use of DONT_TOUCH or KEEP_HIERARCHY.
+set async_fifo_cells [get_cells -hier -regexp -filter {ORIG_REF_NAME =~ {prim_fifo_async(_simple)?}}]
+set async_fifo_pins [get_pins -filter {REF_PIN_NAME =~ rdata_o*} -of $async_fifo_cells]
+set async_fifo_startpoints [all_fanin -startpoints_only -flat $async_fifo_pins]
+# Specify `-through` as well as `-from` to avoid including non-rdata_o paths,
+# such as paths from the read pointers that stay internal or exit via rvalid_o.
+set_false_path -from $async_fifo_startpoints -through $async_fifo_pins


### PR DESCRIPTION
Set `DONT_TOUCH` on 2-stage synchronisers and asynchronous FIFOs to prevent hierarchical boundary/ports being messed with. Then find each of them and set appropriate `false_path` timing exceptions on them using the hierarchical ports.

This does not waive all CDC warnings about these crossings, but should ensure they do not get oddly optimised and are correctly excluded from timing analysis.