### PR TITLE
Introduce option to run legacy software on the same simulator build

### DIFF
--- a/dv/verilator/sonata_system.cc
+++ b/dv/verilator/sonata_system.cc
@@ -38,6 +38,17 @@ int SonataSystem::Main(int argc, char **argv) {
 int SonataSystem::Setup(int argc, char **argv, bool &exit_app) {
   VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
 
+  // Default to CHERI enabled, but this may be overridden on the command line
+  // for running legacy non-CHERI software on the same build of the simulator.
+  _top.disable_cheri = 0;
+  for (int i = 1; i < argc; ++i) {
+    if (!strcmp(argv[i], "--run-legacy-software")) {
+      std::cout << "Disabling CHERI to run legacy software" << std::endl;
+      _top.disable_cheri = 1;
+      break;
+    }
+  }
+
   simctrl.SetTop(&_top, &_top.clk_i, &_top.rst_ni,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This is the top level that connects the system to the virtual devices.
-module top_verilator (input logic clk_i, rst_ni);
+module top_verilator (input logic clk_i, rst_ni, disable_cheri);
   parameter bit DisableHyperram = 1'b0;
 
   // System clock frequency.
@@ -11,7 +11,6 @@ module top_verilator (input logic clk_i, rst_ni);
   // HyperRAM clock frequency.
   localparam int unsigned HRClkFreq  = 100_000_000;
   localparam BaudRate       = 921_600;
-  localparam EnableCHERI    = 1'b1;
 
   logic uart_sys_rx, uart_sys_tx;
 
@@ -200,7 +199,7 @@ module top_verilator (input logic clk_i, rst_ni);
     .spi_mkr_tx_o ( ),
     .spi_mkr_sck_o( ),
 
-    .cheri_en_i (EnableCHERI),
+    .cheri_en_i (!disable_cheri),
     // CHERI output
     .cheri_err_o(),
     .cheri_en_o (),


### PR DESCRIPTION
Simulation builds default to CHERI, but legacy software may be executed on the same build by supplying a command-line option `--run-legacy-software` when running the simulator.
With the simulator builds now taking rather a long time, this is a very useful development aid. It may be of some assistance with automated testing too at some point.