### PR TITLE
Implement I2C DPI and device models

### DIFF
--- a/dv/dpi/i2cdpi/i2c_as621x.cc
+++ b/dv/dpi/i2cdpi/i2c_as621x.cc
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdlib.h>
+
+#include "i2c_as621x.hh"
+
+// Bus reset; reset the device state.
+void i2c_as621x::busReset() {
+  i2cdevice::busReset();
+  index = 0u;
+  byteCount = 0u;
+}
+
+// Start condition occurred on the I2C bus (broadcast to all devices).
+void i2c_as621x::startCond() {
+  i2cdevice::startCond();
+  byteCount = 0u;
+}
+
+// Write a byte of data to the AS612x Digital Temperature Sensor.
+bool i2c_as621x::writeByte(uint8_t inByte, uint32_t oobIn) {
+  // Word write programs the Index register and then optionally the 16 bits of the register
+  // selected by the Index register.
+  switch (byteCount) {
+    case 0u:
+      if (!(index >> 2)) index = inByte & 3u;
+      break;
+    case 1u: dataHi = inByte; break;
+    case 2u:  {
+      uint16_t val = ((uint16_t)dataHi << 8) | inByte;
+      switch (index) {
+        case 0u: break; // 'tval' register is Read Only
+        case 1u: config = val; break;
+        case 2u: tlow   = val; break;
+        default: thigh  = val; break;
+      }
+    }
+    break;
+  }
+  byteCount++;
+  // Byte accepted (send ACK).
+  return true;
+}
+
+// Read a byte of data from the AS612x Digital Temperature Sensor.
+bool i2c_as621x::readByte(uint32_t oobIn, uint8_t &outByte, uint32_t &oobOut) {
+  // Collect the contents of the selected register; Word Read returns 16 bits from the register
+  // indicated by the Index register which must have been written already.
+  uint16_t val;
+  switch (index & 3u) {
+    case 0u: {
+      // Random fluctuations of temperature across the range 24-26 degrees.
+      val = 0xc00u + (rand() & 0xffu);
+    }
+    break;
+    case 1u: val = config; break;
+    case 2u: val = tlow;   break;
+    default: val = thigh;  break;
+  }
+
+  logText("AS621x returning 0x%04x from reg %u\n", val, index & 3u);
+  outByte = (byteCount & 1u) ? (uint8_t)val : (uint8_t)(val >> 8);
+  byteCount ^= 1u;
+  // Byte available, transmit to controller.
+  return true;
+}

--- a/dv/dpi/i2cdpi/i2c_as621x.hh
+++ b/dv/dpi/i2cdpi/i2c_as621x.hh
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "i2cdevice.hh"
+
+// Model of AS621x Digital Temperature Sensor.
+class i2c_as621x : public i2cdevice {
+public:
+  i2c_as621x(i2caddr_t addr) : i2cdevice(addr) {
+    busReset();
+  }
+
+protected:
+  // Bus reset condition.
+  virtual void busReset();
+
+  // Start condition occurred on the I2C bus (broadcast to all devices).
+  virtual void startCond();
+
+  // Write a byte of data to the AS621x Digital Temperature Sensor.
+  virtual bool writeByte(uint8_t inByte, uint32_t oobIn);
+
+  // Read a byte of data from the AS621x Digital Temperature Sensor.
+  virtual bool readByte(uint32_t oobIn, uint8_t &outByte, uint32_t &oobOut);
+
+private:
+  // Number of bytes transferred in current transcation.
+  uint8_t byteCount;
+
+  // High byte of two-byte write operation (the MS byte is transmitted first).
+  uint8_t dataHi;
+
+  // Current temperature value (tval) is not stored; value is generated when read.
+  // CONFIGuration register.
+  uint16_t config;
+  // TLOW and THIGH temperature threshold values.
+  uint16_t tlow;
+  uint16_t thigh;
+  // Index register selects amongt the 4 registers above.
+  uint8_t  index;
+};

--- a/dv/dpi/i2cdpi/i2c_hat_id.cc
+++ b/dv/dpi/i2cdpi/i2c_hat_id.cc
@@ -1,0 +1,86 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "i2c_hat_id.hh"
+
+// Captured EEPROM ID header from Raspberry Pi Sense HAT; this device is not Read Only and it
+// supports Byte/Page Writes too. This static signature is used to initialise the memory.
+static const uint8_t id[] = {
+ 0x52, 0x2D, 0x50, 0x69, 0x01, 0x00, 0x03, 0x00,
+ 0xF0, 0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // R-Pi............
+ 0x2D, 0x00, 0x00, 0x00, 0xE7, 0x58, 0xD1, 0x95,
+ 0xF1, 0x56, 0x28, 0xAB, 0xCB, 0x4E, 0x99, 0x42, // -....X...V(..N.B
+ 0xC7, 0x79, 0xD6, 0xA3, 0x01, 0x00, 0x01, 0x00,
+ 0x0C, 0x09, 0x52, 0x61, 0x73, 0x70, 0x62, 0x65, // .y........Raspbe
+ 0x72, 0x72, 0x79, 0x20, 0x50, 0x69, 0x53, 0x65,
+ 0x6E, 0x73, 0x65, 0x20, 0x48, 0x41, 0x54, 0x7F, // rry PiSense HAT.
+ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ................
+ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ................
+ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ................
+ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // ................
+};
+
+// Both of these are physical device properties so they should not be changed anyway,
+// but they must be powers of two for the logic to work.
+static_assert(!(i2c_hat_id::kMemSize  & (i2c_hat_id::kMemSize  - 1u)));
+static_assert(!(i2c_hat_id::kPageSize & (i2c_hat_id::kPageSize - 1u)));
+
+// Constructor initialises the device state.
+i2c_hat_id::i2c_hat_id(i2caddr_t addr) : i2cdevice(addr) {
+  busReset();
+  // Initialise the memory contents from the static signature above.
+  assert(sizeof(mem) >= sizeof(id));
+  memcpy(mem, id, sizeof(id));
+}
+
+// Bus reset condition; reset the device.
+void i2c_hat_id::busReset() {
+  i2cdevice::busReset();
+  byteCount = 0u;
+  currAddr = 0u;
+}
+
+// Start condition occurred on the I2C bus (broadcast to all devices).
+void i2c_hat_id::startCond() {
+  i2cdevice::startCond();
+  byteCount = 0u;
+}
+
+// Write a byte of data to the the RPi Sense HAT ID EEPROM.
+bool i2c_hat_id::writeByte(uint8_t inByte, uint32_t oobIn) {
+  switch (byteCount) {
+    case 0u: currAddr = (uint16_t)inByte << 8; break;
+    case 1u: currAddr |= inByte; break;
+    default:
+      // Note: this is probably not modelling write behaviour properly.
+      logText("HAT ID writing byte 0x%0x to addr 0x%0x\n", inByte, currAddr);
+      mem[currAddr & (kMemSize - 1u)] = inByte;
+      // Auto-increment address; addressing wraps at the end of the page.
+      currAddr++;
+      if (!(currAddr & kPageSize)) currAddr -= kPageSize;
+      break;
+  }
+  byteCount++;
+  // Byte accepted, send ACK.
+  return true;
+}
+
+// Read a byte of data from the RPi Sense HAT ID EEPROM.
+bool i2c_hat_id::readByte(uint32_t oobIn, uint8_t &outByte, uint32_t &oobOut) {
+  outByte = mem[currAddr & (kMemSize - 1u)];
+  oobOut = 0u;
+  logText("HAT ID reading byte 0x%0x from addr 0x%0x\n", outByte, currAddr);
+  // Auto-increment address.
+  currAddr++;
+  // Byte available, transmit to controller.
+  return true;
+}

--- a/dv/dpi/i2cdpi/i2c_hat_id.hh
+++ b/dv/dpi/i2cdpi/i2c_hat_id.hh
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __DV_DPI_I2CDPI_I2C_HAT_ID_H_
+#define __DV_DPI_I2CDPI_I2C_HAT_ID_H_
+#include "i2cdevice.hh"
+
+// Model of ID EEPROM on the Raspberry Pi Sense HAT.
+class i2c_hat_id : public i2cdevice {
+public:
+  i2c_hat_id(i2caddr_t addr);
+
+  // Physical properties of the EEPROM.
+  static constexpr unsigned kPageSize = 0x20u;   // Pages are 32 bytes.
+  static constexpr unsigned kMemSize  = 0x1000u; // 32Kib.
+protected:
+  // Bus reset.
+  virtual void busReset();
+
+  // Start condition occurred on the I2C bus (broadcast to all devices).
+  virtual void startCond();
+
+  // Write a byte of data to the AS621x Digital Temperature Sensor.
+  virtual bool writeByte(uint8_t inByte, uint32_t oobIn);
+
+  // Read a byte of data from the AS621x Digital Temperature Sensor.
+  virtual bool readByte(uint32_t oobIn, uint8_t &outByte, uint32_t &oobOut);
+
+private:
+  // Number of bytes transferred in current transcation.
+  uint8_t byteCount;
+
+  // Current address within the EEPROM.
+  uint16_t currAddr;
+
+  // Memory contents.
+  uint8_t mem[kMemSize];
+};
+#endif  // __DV_DPI_I2CDPI_I2C_HAT_ID_H_

--- a/dv/dpi/i2cdpi/i2c_lsm9ds1.cc
+++ b/dv/dpi/i2cdpi/i2c_lsm9ds1.cc
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "i2c_lsm9ds1.hh"
+
+// Device reset.
+void i2c_lsm9ds1::busReset() {
+  i2cdevice::busReset();
+  regNum = 0u;
+}
+
+// Write a byte of data to the LSM9DS1 IMU.
+bool i2c_lsm9ds1::writeByte(uint8_t inByte, uint32_t oobIn) {
+  // The model is very limited; we are interested only in the 'WHO_AM_I' ID registers for now.
+  regNum = inByte;
+  // Byte accepted, send ACK.
+  return true;
+}
+
+// Read a byte of data from LSM9DS1 IMU.
+bool i2c_lsm9ds1::readByte(uint32_t oobIn, uint8_t &outByte, uint32_t &oobOut) {
+  // The model is very limited; we are interested only in the 'WHO_AM_I' ID registers for now.
+  switch (regNum) {
+    case 0x0fu: {
+      // This single IC presents as two I2C targets.
+      switch (devAddress) {
+        // Accelerometer and Gyroscope.
+        case 0x6au: outByte = 0x68u; break;
+        // Magnetic sensor.
+        case 0x1cu: outByte = 0x3du; break;
+        default: outByte = 0xffu; break;
+      }
+    }
+    break;
+    default: outByte = 0xffu; break;
+  }
+  oobOut = 0u;
+  // Byte available, transmit to controller.
+  return true;
+}

--- a/dv/dpi/i2cdpi/i2c_lsm9ds1.hh
+++ b/dv/dpi/i2cdpi/i2c_lsm9ds1.hh
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __DV_DPI_I2CDPI_I2C_LSM9DS1_H_
+#define __DV_DPI_I2CDPI_I2C_LSM9DS1_H_
+#include "i2cdevice.hh"
+
+// iNEMO intertial module: 3D accelerometer, 3D gyroscope, 3D magnetometer.
+// Included on the Raspberry Pi Sense HAT. Model just reponds to reads from 'WHO_AM_I' ID registers.
+class i2c_lsm9ds1 : public i2cdevice {
+public:
+  // Note: this IMU device is unusual in that it presents as two devices, at distinct addresses
+  // on the I2C bus. Therefore two device instances are required to model the full functionality.
+  i2c_lsm9ds1(i2caddr_t addr) : i2cdevice(addr) {
+    busReset();
+  }
+
+protected:
+  // Bus reset.
+  virtual void busReset();
+
+  // Write a byte of data to the LSM9DS1 IMU.
+  virtual bool writeByte(uint8_t inByte, uint32_t oobIn);
+
+  // Read a byte of data from the LSM9DS1 IMU.
+  virtual bool readByte(uint32_t oobIn, uint8_t &outByte, uint32_t &oobOut);
+private:
+  // Selected register.
+  uint8_t regNum;
+};
+#endif  // __DV_DPI_I2CDPI_I2C_LSM9DS1_H_

--- a/dv/dpi/i2cdpi/i2cdevice.cc
+++ b/dv/dpi/i2cdpi/i2cdevice.cc
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "i2cdevice.hh"
+
+// Logging utility function.
+void i2cdevice::logText(const char *fmt, ...) {
+  if (logging) {
+    va_list va;
+    va_start(va, fmt);
+    vprintf(fmt, va);
+    va_end(va);
+  }
+}

--- a/dv/dpi/i2cdpi/i2cdevice.hh
+++ b/dv/dpi/i2cdpi/i2cdevice.hh
@@ -1,0 +1,60 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __DV_DPI_I2CDPI_I2CDEVICE_H_
+#define __DV_DPI_I2CDPI_I2CDEVICE_H_
+#include <stdint.h>
+
+// I2C addresses are actually 7 bits typically.
+typedef uint8_t i2caddr_t;
+
+class i2cdevice {
+public:
+  i2cdevice(i2caddr_t addr, bool log = false) : logging(log), devAddress(addr) {
+    busReset();
+  }
+  virtual ~i2cdevice() { }
+
+  // Return the I2C address of this device.
+  i2caddr_t getAddress() const { return devAddress; }
+
+  // Bus reset.
+  virtual void busReset(void) { }
+
+  // Start condition occurred on the I2C bus (broadcast to all devices).
+  virtual void startCond() { }
+
+  // Restart condition occurred on the I2C bus for this specific device.
+  virtual void restartCond() { }
+
+  // Access starting.
+  virtual void accessStarting(bool read) { }
+
+  // Stop condition occurred on the I2C bus for this specific device.
+  virtual void stopCond() { }
+
+  // Write a byte of data to the I2C device.
+  virtual bool writeByte(uint8_t inByte, uint32_t oobIn) {
+    // Sink consumes all write traffic.
+    return true;
+  }
+
+  // Read a byte of data from the I2C device.
+  virtual bool readByte(uint32_t oobIn, uint8_t &outByte, uint32_t &oobOut) {
+    // Sources no read traffic.
+    outByte = 0xffu; // Open drain bus.
+    oobOut = 0u;
+    return false;
+  }
+
+protected:
+  // Diagnostic logging output.
+  void logText(const char *fmt, ...);
+
+  // Enable diagnostic logging output?
+  bool logging;
+
+  i2caddr_t devAddress;
+};
+#endif

--- a/dv/dpi/i2cdpi/i2cdpi.cc
+++ b/dv/dpi/i2cdpi/i2cdpi.cc
@@ -1,0 +1,262 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "i2cdpi.hh"
+#include "i2c_as621x.hh"
+#include "i2c_hat_id.hh"
+#include "i2c_lsm9ds1.hh"
+
+// Bus reset signalling.
+uint32_t i2cdpi::under_reset(bool scl, bool sda, uint32_t oobIn, uint32_t &oobOut) {
+  state = I2C_Idle;
+  numBits = 0u;
+  // No active transaction.
+  currDevice = nullptr;
+  reading = false;
+  sendAck = true;
+  // Reset asserted, SCL and SDA inactive.
+  prev_rst = true;
+  prev_scl = true;
+  prev_sda = true;
+  // Note: Perhaps one or more devices may wish to emit non-zero Out-Of-Band signals under reset
+  // at some point, but presently nothing uses these signals. OOB signals would classically be
+  // interrupt lines and if shared they may need to default to being high.
+  oobOut = 0u;
+  latestOobOut = oobOut;
+  // Produce outputs.
+  return (prev_sda << 1) | prev_scl;
+}
+
+// Decode I2C bus signalling and produce appropriate responses.
+uint32_t i2cdpi::decode(bool scl, bool sda, uint32_t oobIn, uint32_t &oobOut) {
+  // Inform all devices of the end of a bus reset condition.
+  if (prev_rst) {
+    for (const auto &dev : devs) dev.second->busReset();
+    prev_rst = false;
+  }
+
+  // Keep the Out-Of-Band output signals stabled by default.
+  oobOut = latestOobOut;
+  // SCL and SDA lines are pulled high when undriven; open drain bus.
+  bool sda_out = true;
+  // Note: We presently do not implement support for clock stretching so our contribution to the
+  // SCL line is to leave it undriven (high) at all times.
+  bool scl_out = true;
+
+  switch (state) {
+    case I2C_Idle:
+      // Start condition?
+      if (prev_sda && !sda) {
+        start_cond();
+        state = I2C_Addr;
+        numBits = 0u;
+      }
+      break;
+
+    // The first byte of a transaction consists of a 7-bit address followed by a single R/nW
+    // indication of the direction of the transfer.
+    case I2C_Addr:
+      // SDA shall be sampled when SCL is high; respond on the rising edge.
+      if (!prev_scl && scl) {
+        // Collect Address and R/nW indicator; bytes are transferred MSB first.
+        currByte = (currByte << 1) | (sda ? 1u : 0u);
+        if (++numBits >= 8u) {
+          // Attempt to locate this device; 7 MSBs of the first byte specify the
+          // address of the target device.
+          i2caddr_t addr = currByte >> 1;
+          // Remember whether this is a read operation or a write operation.
+          reading = (currByte & 1u);
+          logText("Addressing target 0x%0x read %c\n", addr, reading ? 'Y' : 'N');
+          currDevice = find_device(addr);
+          if (currDevice) {
+            // Notify the device that a transaction is being attempted.
+            currDevice->accessStarting(reading);
+            if (reading) {
+              if (!currDevice->readByte(oobIn, currByte, oobOut)) {
+                currByte = 0xffu;
+              }
+              // Retain these signals so that we may keep them stable.
+              latestOobOut = oobOut;
+            }
+            sendAck = true;
+          } else {
+            // No target/device at the given address.
+            sendAck = false;
+          }
+          // Start counting the transmitted bits of this new byte.
+          numBits = 0u;
+          state = I2C_GotAddr;
+        }
+      }
+      break;
+
+    case I2C_GotAddr:
+    case I2C_GotData:
+      // Await the falling edge of SCL, and then we can change the SDA line
+      // to ACK if the targeted device exists.
+      if (prev_scl && !scl) {
+        sda_out = !sendAck;  // ACK is indicated by pulling SDA low.
+        state = I2C_SendAckNak;
+      }
+      break;
+
+    case I2C_SendAckNak:
+      sda_out = !currDevice;
+      // Await the falling edge of SCL that indicates the ACK/NAK (9th) bit has been sampled.
+      if (prev_scl && !scl) {
+        state = I2C_Data;
+      }
+      break;
+
+    case I2C_SentData:
+      if (!prev_scl && scl) {
+        // ACK/NAK response from the controller.
+        bool ack = !sda;
+        if (ack && !currDevice->readByte(oobIn, currByte, oobOut)) {
+          currByte = 0xffu;
+        }
+        // Retain these signals so that we may keep them stable.
+        latestOobOut = oobOut;
+        // Start count the transmitted bits of this new byte.
+        numBits = 0u;
+        state = I2C_GotAckNak;
+      }
+      break;
+
+    case I2C_GotAckNak:
+      if (prev_scl && !scl) {
+        state = I2C_Data;
+      }
+      break;
+
+    case I2C_Data:
+      // A rising edge on SDA whilst SCL is high indicates a stoP condition.
+      if (scl && !prev_sda && sda) {
+        if (currDevice) {
+          currDevice->stopCond();
+          currDevice = nullptr;
+        }
+        state = I2C_Idle;
+      } else if (scl && prev_sda && !sda) {
+        // A falling edge on SDA whilst SCL is high indicates a repeated start (Sr) condition.
+        if (currDevice) {
+          currDevice->restartCond();
+          currDevice = nullptr;
+        }
+        state = I2C_Addr;
+        numBits = 0u;
+      } else if (reading) {
+        // Emit the MS bit not yet completed; bytes are transferred Most Significant Bit first.
+        sda_out = (currByte & 0x80u) != 0u;
+        // When the operation is a read, we must launch the data during the interval for which
+        // SCL is deasserted; this avoids transitions during the interval for which SCL is asserted.
+        if (prev_scl && !scl) {
+          // Shift read byte; ensure SDA returns high.
+          currByte = (currByte << 1) | 1u;
+          if (++numBits >= 8u) {
+            state = I2C_SentData;
+          }
+        }
+      } else {
+        // When the operation is a write, the data will be stable throughout the interval for which
+        // SCL is asserted; sample it on the rising edge.
+        if (!prev_scl && scl) {
+          currByte = (currByte << 1) | (sda ? 1u : 0u);
+          if (++numBits >= 8u) {
+            sendAck = currDevice->writeByte(currByte, oobIn);
+            numBits = 0u;
+            state = I2C_GotData;
+          }
+        }
+      }
+      break;
+
+    default:
+      logText("Invalid/unexpected device state 0x%0x\n", state);
+      state = I2C_Idle;
+      break;
+  }
+  // Remember the new state of the I2C bus so that we can detect future changes.
+  prev_sda = sda;
+  prev_scl = scl;
+  // Produce outputs.
+  return (sda_out << 1) | scl_out;
+}
+
+// Logging utility function.
+void i2cdpi::logText(const char *fmt, ...) {
+  if (logging) {
+    va_list va;
+    va_start(va, fmt);
+    vprintf(fmt, va);
+    va_end(va);
+  }
+}
+
+extern "C" {
+// Initialisation of DPI on the given I2C bus and attach the appropriate devices.
+// Note: perhaps the bus configuration should be read from a configuration file at some point.
+void *i2cdpi_create(const char *id) {
+  i2cdpi *i2c = new i2cdpi();
+  assert(i2c);
+  // Create the appropriate devices for this bus.
+  if (!strcmp(id, "i2c0")) {
+    // RPI Sense HAT ID EEPROM
+    const i2caddr_t id_addr = 0x50u;
+    i2cdevice *id_device = new i2c_hat_id(id_addr);
+    assert(id_device);
+    i2c->add_device(id_device);
+    i2c->logText("I2C0 created\n", id);
+  } else if (!strcmp(id, "i2c1")) {
+    // RPI Sense HAT IMU; this presents at two separate I2C addresses.
+    const i2caddr_t imu_accgyr_addr = 0x6au;  // Accelerometer/gyroscope.
+    i2cdevice *imu_accgyr_device = new i2c_lsm9ds1(imu_accgyr_addr);
+    assert(imu_accgyr_device);
+    const i2caddr_t imu_mag_addr = 0x1cu;  // Magnetometer.
+    i2cdevice *imu_mag_device = new i2c_lsm9ds1(imu_mag_addr);
+    assert(imu_mag_device);
+    i2c->add_device(imu_accgyr_device);
+    i2c->add_device(imu_mag_device);
+    // Digital Temperature Sensor.
+    const i2caddr_t dst_addr = 0x48u;
+    i2cdevice *dst_device = new i2c_as621x(dst_addr);
+    assert(dst_device);
+    i2c->add_device(dst_device);
+    i2c->logText("I2C1 created\n", id);
+  } else {
+    i2c->logText("Info: I2C bus '%s' is unpopulated\n", id);
+  }
+  return (void *)i2c;
+}
+
+// Finalisation of I2C devices and DPI model.
+void i2cdpi_destroy(void *ctx_v) {
+  i2cdpi *i2c = (i2cdpi *)ctx_v;
+  assert(i2c);
+  delete i2c;
+}
+
+// Bus reset signalling on the given I2C bus; produce appropriate outputs.
+uint32_t i2cdpi_under_reset(void *ctx_v, uint32_t sda_scl, uint32_t oobIn) {
+  i2cdpi *i2c = (i2cdpi *)ctx_v;
+  uint32_t oobOut;
+  assert(i2c);
+  sda_scl = i2c->under_reset((sda_scl & 1u) != 0u, (sda_scl & 2u) != 0u, oobIn, oobOut);
+  return (oobOut << 2) | (sda_scl & 3u);
+}
+
+// Decode I2C signalling on the given bus and produce updated outputs.
+uint32_t i2cdpi_decode(void *ctx_v, uint32_t sda_scl, uint32_t oobIn) {
+  i2cdpi *i2c = (i2cdpi *)ctx_v;
+  uint32_t oobOut;
+  assert(i2c);
+  sda_scl = i2c->decode((sda_scl & 1u) != 0u, (sda_scl & 2u) != 0u, oobIn, oobOut);
+  return (oobOut << 2) | (sda_scl & 3u);
+}
+};

--- a/dv/dpi/i2cdpi/i2cdpi.hh
+++ b/dv/dpi/i2cdpi/i2cdpi.hh
@@ -1,0 +1,107 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __DV_DPI_I2CDPI_I2CDPI_H_
+#define __DV_DPI_I2CDPI_I2CDPI_H_
+#include <map>
+#include "i2cdevice.hh"
+
+// DPI model of an I2C bus and the communication with attached devices; the DPI model performs all
+// the work of serialising/deserialising the byte-level traffic, address decoding and the handling
+// of ACK/NAK signalling.
+//
+// Communication with the attached I2C device models occurs at the level of bytes to keep them
+// simple. Devices are also informed of (S)tart, repeated start (Sr) and sto(P) conditions if they
+// require.
+class i2cdpi {
+public:
+  i2cdpi(bool log = false) :
+    logging(log),
+    prev_rst(false),
+    prev_scl(true),
+    prev_sda(true),
+    latestOobOut(0u),
+    currByte(0u),
+    numBits(0u),
+    currDevice(nullptr),
+    reading(false),
+    sendAck(true) { }
+
+  // Destructor for I2C DPI model; deletes all attached devices.
+  ~i2cdpi() {
+    for (const auto &dev : devs) dev.second->startCond();
+    devs.clear();
+  }
+
+  // Add a device to this bus.
+  void add_device(i2cdevice *dev) {
+    (void)devs.insert(std::pair<i2caddr_t, i2cdevice *>(dev->getAddress(), dev));
+  }
+
+  // Return access to the device at the given target address, iff present.
+  i2cdevice *find_device(i2caddr_t addr) {
+    auto match = devs.find(addr);
+    return (match == devs.end()) ? nullptr : (*match).second;
+  }
+
+  // Bus reset signalling.
+  uint32_t under_reset(bool scl, bool sda, uint32_t oobIn, uint32_t &oobOut);
+
+  // Decode I2C bus signalling.
+  uint32_t decode(bool scl, bool sda, uint32_t oobIn, uint32_t &oobOut);
+
+  // Diagnostic logging utility function.
+  void logText(const char *fmt, ...);
+
+  // Enable diagnostic logging output?
+  bool logging;
+
+private:
+  // Broadcast(S)tart condition to all devices; we cannot yet know which is being addressed.
+  inline void start_cond() {
+    for (const auto &dev : devs) dev.second->startCond();
+  }
+
+  // Current state of I2C bus/decoding.
+  enum {
+    I2C_Idle,
+    I2C_Start,
+    I2C_Restart,
+    I2C_Addr,
+    I2C_GotAddr,
+    I2C_SendAckNak,
+    I2C_Data,
+    I2C_GotData,
+    I2C_SentData,
+    I2C_GotAckNak
+  } state;
+
+  // Previous state of Bus Reset signal.
+  bool prev_rst;
+  // Previous state of I2C bus.
+  bool prev_scl;
+  bool prev_sda;
+
+  // Most recent Out-Of-Band output signals on this I2C bus.
+  uint32_t latestOobOut;
+
+  // Current input/output byte.
+  uint8_t currByte;
+  // Number of bits received/transmitted (within current byte).
+  uint8_t numBits;
+
+  // Target device for the current transaction.
+  i2cdevice *currDevice;
+
+  // Current transaction is a read operation.
+  bool reading;
+
+  // Device has chosen to ACK the current byte of a write transaction.
+  bool sendAck;
+
+  // Devices connected to this bus.
+  typedef std::pair<i2caddr_t, i2cdevice *> dev_entry;
+  std::map<i2caddr_t, i2cdevice *> devs;
+};
+#endif  // __DV_DPI_I2CDPI_I2CDPI_H_

--- a/dv/dpi/i2cdpi/i2cdpi.sv
+++ b/dv/dpi/i2cdpi/i2cdpi.sv
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module i2cdpi #(
+  // Bus identification.
+  parameter string ID = "i2c",
+  // Number of Out-Of-Band Input bits.
+  parameter int unsigned OOB_InW  = 1,
+  // Number of Out-Of-Band Output bits.
+  parameter int unsigned OOB_OutW = 1
+) (
+  input  logic rst_ni,
+
+  // Input signals from the I2C controller.
+  input  logic scl_i,
+  input  logic sda_i,
+  // Outputs to the controller; SCL may be used to implement
+  // clock-stretching and SDA provides ACKs and read data.
+  output logic scl_o,
+  output logic sda_o,
+
+  // Out-Of-Band input/output signals carry additional information if required.
+  input  logic [OOB_InW-1:0]  oob_in,
+  output logic [OOB_OutW-1:0] oob_out
+);
+
+chandle ctx;
+
+// I2C DPI initialisation; DPI model is supplied with the bus identification string and
+// can attach devices accordingly.
+import "DPI-C" function
+  chandle i2cdpi_create(input string name);
+
+// I2C DPI finalisation.
+import "DPI-C" function
+  void i2cdpi_destroy(input chandle ctx);
+
+// I2C Bus Reset.
+import "DPI-C" function
+  int unsigned i2cdpi_under_reset(input chandle ctx, int unsigned sda_scl, int unsigned oob_in);
+
+// Decode I2C bus signals.
+import "DPI-C" function
+  int unsigned i2cdpi_decode(input chandle ctx, int unsigned sda_scl, int unsigned oob_in);
+
+// Initialisation of I2C DPI model.
+initial begin
+  ctx = i2cdpi_create(ID);
+end
+// Finalisation of I2C DPI model.
+final begin
+  i2cdpi_destroy(ctx);
+end
+
+// Inform of the I2C DPI model of Bus Reset conditions and I2C signal changes.
+logic [31:0] out_q;
+always_comb begin
+  if (!rst_ni) out_q = i2cdpi_under_reset(ctx, 32'({sda_i, scl_i}), 32'(oob_in));
+  else out_q = i2cdpi_decode(ctx, 32'({sda_i, scl_i}), 32'(oob_in));
+end
+
+wire unused_ = ^out_q[31:OOB_OutW+2];
+assign {oob_out, sda_o, scl_o} = out_q[OOB_OutW+1:0];
+
+endmodule

--- a/sonata.core
+++ b/sonata.core
@@ -29,6 +29,17 @@ filesets:
       - lowrisc:dv_dpi_c:usbdpi:0.1
       - lowrisc:dv_dpi_sv:usbdpi:0.1
     files:
+      - dv/dpi/i2cdpi/i2c_lsm9ds1.cc: { file_type: cppSource }
+      - dv/dpi/i2cdpi/i2c_lsm9ds1.hh: { file_type: cppSource, is_include_file: true }
+      - dv/dpi/i2cdpi/i2c_as621x.cc: { file_type: cppSource }
+      - dv/dpi/i2cdpi/i2c_as621x.hh: { file_type: cppSource, is_include_file: true }
+      - dv/dpi/i2cdpi/i2c_hat_id.cc: { file_type: cppSource }
+      - dv/dpi/i2cdpi/i2c_hat_id.hh: { file_type: cppSource, is_include_file: true }
+      - dv/dpi/i2cdpi/i2cdevice.cc: { file_type: cppSource }
+      - dv/dpi/i2cdpi/i2cdevice.hh: { file_type: cppSource, is_include_file: true }
+      - dv/dpi/i2cdpi/i2cdpi.sv: { file_type: systemVerilogSource }
+      - dv/dpi/i2cdpi/i2cdpi.cc: { file_type: cppSource }
+      - dv/dpi/i2cdpi/i2cdpi.hh: { file_type: cppSource, is_include_file: true }
       - dv/dpi/spidpi/spidpi.sv: { file_type: systemVerilogSource }
       - dv/dpi/spidpi/spidpi.cc: { file_type: cppSource }
       - dv/dpi/spidpi/spidpi.hh: { file_type: cppSource, is_include_file: true }

--- a/sw/legacy/demo/i2c_hat_id/i2c_hat_id.c
+++ b/sw/legacy/demo/i2c_hat_id/i2c_hat_id.c
@@ -81,7 +81,7 @@ static int as6212_temperature_report(void) {
   }
   uint16_t temp = (buf[0] << 8) | buf[1];
 
-  putstr("AS612 Temperature Sensor - Config 0x");
+  putstr("AS6212 Temperature Sensor - Config 0x");
   puthexn(config, 4);
   putstr(" Temp 0x");
   puthexn(temp, 4);
@@ -180,10 +180,12 @@ int main(void) {
   setup_bus(i2c1);
 
   uint64_t last_elapsed_time = get_elapsed_time();
-  int iter                   = 0;
+  // Do not wait on the first iteration; faster results in simulation.
+  bool first = true;
+  int iter   = 0;
   while (1) {
     uint64_t cur_time = get_elapsed_time();
-    if (cur_time != last_elapsed_time) {
+    if (first || cur_time != last_elapsed_time) {
       last_elapsed_time = cur_time;
 
       int rc = 0;
@@ -208,6 +210,7 @@ int main(void) {
         return rc;
       }
 #endif
+      first = false;
       iter++;
     }
   }


### PR DESCRIPTION
Introduce a generic DPI model of an I2C bus with an arbitrary number of attached I2C devices. All bus speeds and device behaviours including Sr (restart) conditions should be supported, and only support for clock stretching and multiple controllers is presently unimplemented. Out-Of-Band signals are present in each direction for future extensions such as interrupt signalling.

Introduce simple device models for:
-  RPi Sense HAT ID EEPROM
- RPi Sense HAT IMU (`WHO_AM_I` registers only)
- AS621x Digital Temperature Sensor

These are the devices that are presently anticipated and exercised by the `sw/legacy/demo/i2c_hat_id` code, allowing the code to produce the same results in Verilator simulation as on the FPGA build.
