### PR TITLE
Do not modify CS whilst SPI controller is active

### DIFF
--- a/sw/cheri/common/flash-utils.hh
+++ b/sw/cheri/common/flash-utils.hh
@@ -46,10 +46,10 @@ class SpiFlash
 	{
 		set_cs(true);
 		spi->blocking_write(&CmdEnableReset, 1);
-		set_cs(false);
 
-		set_cs(true);
 		spi->blocking_write(&CmdReset, 1);
+
+		spi->wait_idle();
 		set_cs(false);
 
 		// Need to wait at least 30us for the reset to complete.
@@ -73,13 +73,9 @@ class SpiFlash
 
 		set_cs(true);
 		spi->blocking_write(&CmdWriteEnable, 1);
-		set_cs(false);
 
-		set_cs(true);
 		spi->blocking_write(erase_cmd, 4);
-		set_cs(false);
 
-		set_cs(true);
 		spi->blocking_write(&CmdReadStatusRegister1, 1);
 
 		uint8_t status;
@@ -100,14 +96,10 @@ class SpiFlash
 
 		set_cs(true);
 		spi->blocking_write(&CmdWriteEnable, 1);
-		set_cs(false);
 
-		set_cs(true);
 		spi->blocking_write(write_cmd, 4);
 		spi->blocking_write(data, 256);
-		set_cs(false);
 
-		set_cs(true);
 		spi->blocking_write(&CmdReadStatusRegister1, 1);
 
 		uint8_t status;


### PR DESCRIPTION
Ensure that CS is not changed whilst the SPI controller is active, e.g. after a write into the FIFO that has not necessarily completed on the SPI bus.
It is safe to deassert the CS line when a read operation has completed because that necessarily blocks until completion.

The code worked in practice by dint of the CPU writes into the FIFO being slow enough that the SPI at 15Mbps can mostly keep up. If the SPI is slowed to eg. 30/8Mbps then the code `sw/cheri/checks/spi_test` produced incorrect results in Verilator simulation because the spidpi model responds to the changes on the CS line.

Such issues with the CS line-driving may exist elsewhere in the codebase and particularly for other SPI devices.