### PR TITLE
Hook up system clock to pinmux

### DIFF
--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -246,6 +246,8 @@ module top_sonata (
   logic [31:0] gpio_in[GPIO_NUM];
 
   pinmux u_pinmux (
+    .clk_i(clk_sys),
+    .rst_ni(rst_sys_n),
     .uart_tx_i(uart_tx),
     .uart_rx_o(uart_rx),
     .i2c_scl_i(i2c_scl_h2d),


### PR DESCRIPTION
In `top_sonata.sv`, the `clk_i` and `rst_ni` signals were not actually connected to the main system clock and reset signals. This PR hooks them up so that pinmux can actually be used on FPGA.