### PR TITLE
Moved verilator specific function out of sonata_system

### DIFF
--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -477,4 +477,11 @@ module top_verilator (input logic clk_i, rst_ni);
     .oob_in   ({lcd_dc, lcd_rst, lcd_backlight}),
     .oob_out  ( )  // not used.
   );
+
+
+  export "DPI-C" function mhpmcounter_get;
+
+  function automatic longint unsigned mhpmcounter_get(int index);
+    return u_sonata_system.u_top_tracing.u_ibex_top.u_ibex_core.cs_registers_i.mhpmcounter[index];
+  endfunction
 endmodule

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -1365,14 +1365,6 @@ module sonata_system #(
     .td_o
   );
 
-  `ifdef VERILATOR
-    export "DPI-C" function mhpmcounter_get;
-
-    function automatic longint unsigned mhpmcounter_get(int index);
-      return u_top_tracing.u_ibex_top.u_ibex_core.cs_registers_i.mhpmcounter[index];
-    endfunction
-  `endif
-
   for (genvar i = 0; i < NrDevices; i++) begin : gen_unused_device
     if (i != RevTags) begin
       logic _unused_rvalid;


### PR DESCRIPTION
`mhpmcounter_get` is verilator specific, so should live in top_verilator.