### PR TITLE
Re-add CHERIoT RTOS test suite to Nix testing infrastructure.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,9 +161,9 @@
       cheriotRtosSource = pkgs.fetchFromGitHub {
         owner = "lowRISC";
         repo = "CHERIoT-RTOS";
-        rev = "30148bad7ef45026d4e4b754871bf2b396ce2ca8";
+        rev = "444e4965c1dc84414e4959d55e47b0e999c086c9";
         fetchSubmodules = true;
-        hash = "sha256-3yatAEfZ5eWOfQB7w5I6OOHaG39pRUeyzCGgix3T4PI=";
+        hash = "sha256-tXTIKmf/MBXmspcPdKYqQQp8zj6HuUgGXlj+uUCcC40=";
       };
 
       sonata-system-software = pkgs.stdenv.mkDerivation rec {

--- a/flake.nix
+++ b/flake.nix
@@ -228,7 +228,7 @@
         doCheck = true;
         buildInputs = [sonata-simulator pythonEnv];
         checkPhase = ''
-          python ${./util/test_runner.py} -t 30 sim \
+          python ${./util/test_runner.py} -t 60 sim \
               --elf-file ${sonata-system-software}/bin/test_runner
         '';
         installPhase = "mkdir $out";

--- a/flake.nix
+++ b/flake.nix
@@ -218,6 +218,8 @@
           ${./util/test_runner.py} -t 30 fpga "$1" \
             --elf-file ${sonata-system-software}/bin/test_runner \
             --tcl-file ${./util/sonata-openocd-cfg.tcl}
+          ${./util/test_runner.py} -t 600 fpga "$1" \
+            --uf2-file ${cheriot-rtos-test-suite}/share/test-suite.uf2
         '';
       };
 
@@ -230,6 +232,9 @@
         checkPhase = ''
           python ${./util/test_runner.py} -t 60 sim \
               --elf-file ${sonata-system-software}/bin/test_runner
+          python ${./util/test_runner.py} -t 600 sim \
+              --sim-boot-stub ${sonata-sim-boot-stub.out}/share/sim_boot_stub \
+              --elf-file ${cheriot-rtos-test-suite}/share/test-suite
         '';
         installPhase = "mkdir $out";
       };

--- a/sw/cheri/CMakeLists.txt
+++ b/sw/cheri/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.13)
 include(FetchContent)
 
 FetchContent_Declare(CHERIOT_RTOS
-  GIT_REPOSITORY    https://github.com/CHERIoT-Platform/CHERIoT-RTOS
-  GIT_TAG           64d846091a43053fbdd0312fb9419e05429109c6
+  GIT_REPOSITORY    https://github.com/lowRISC/CHERIoT-RTOS
+  GIT_TAG           444e4965c1dc84414e4959d55e47b0e999c086c9
 )
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)


### PR DESCRIPTION
See commits for more detailed explanations.

This PR re-adds testing of the CHERIoT RTOS test suite in our test suite, such that it will now also run in CI where appropriate. To make the test suite work, the CHERIoT RTOS source used in `flake.nix` has been bumped to point to the [`hyperram` branch](https://github.com/lowRISC/cheriot-rtos/tree/hyperram), instead of `main`. To keep these in sync, the corresponding git tag in the relevant CMake build file is also updated. With these changes, the test suite should now once again pass as expected. 

It also doubles the time available for regular tests to run in simulation in CI, because we're getting quite close to the timeout on longer variations after adding the SPI, I2C and hyperram tests, and it already times out locally on my machine.

Not got a board with me at the time of writing, so I haven't had a chance to check this out on FPGA yet - only on simulator.