### PR TITLE
Changed verilator's scope to top_verilator

### DIFF
--- a/dv/verilator/sonata_system.cc
+++ b/dv/verilator/sonata_system.cc
@@ -69,7 +69,7 @@ bool SonataSystem::Finish() {
   // Set the scope to the root scope, the ibex_pcount_string function otherwise
   // doesn't know the scope itself. Could be moved to ibex_pcount_string, but
   // would require a way to set the scope name from here, similar to MemUtil.
-  svSetScope(svGetScopeFromName("TOP.top_verilator.u_sonata_system"));
+  svSetScope(svGetScopeFromName("TOP.top_verilator"));
 
   std::cout << "\nPerformance Counters" << std::endl
             << "====================" << std::endl;


### PR DESCRIPTION
This fixes the problem of `mhpmcounter_get` not being in scope.