### PR TITLE
CHERIoT RTOS version update.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,9 +162,9 @@
       cheriotRtosSource = pkgs.fetchFromGitHub {
         owner = "lowRISC";
         repo = "CHERIoT-RTOS";
-        rev = "444e4965c1dc84414e4959d55e47b0e999c086c9";
+        rev = "06e4dec88b14cb3a432e08995677361c40beb882";
         fetchSubmodules = true;
-        hash = "sha256-tXTIKmf/MBXmspcPdKYqQQp8zj6HuUgGXlj+uUCcC40=";
+        hash = "sha256-5+FWaaKkeLqtl0SRC07ovIyIO/8nvS54kD3tRqXbHdo=";
       };
 
       sonata-system-software = pkgs.stdenv.mkDerivation rec {

--- a/sw/cheri/CMakeLists.txt
+++ b/sw/cheri/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 
 FetchContent_Declare(CHERIOT_RTOS
   GIT_REPOSITORY    https://github.com/lowRISC/CHERIoT-RTOS
-  GIT_TAG           444e4965c1dc84414e4959d55e47b0e999c086c9
+  GIT_TAG           06e4dec88b14cb3a432e08995677361c40beb882
 )
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)


### PR DESCRIPTION
Updated to CHERIoT RTOS to include https://github.com/lowRISC/cheriot-rtos/pull/4

This is the `sonata-system` branch. FYI: All old branches are still available with a number suffix, i.e. `sonata-system-2`.