### PR TITLE
Improve robustness of test_runner

### DIFF
--- a/sw/cheri/common/console-utils.hh
+++ b/sw/cheri/common/console-utils.hh
@@ -25,10 +25,10 @@
 [[maybe_unused]] static void write_test_result(volatile OpenTitanUart *uart, int failures) {
   if (failures == 0) {
     set_console_mode(uart, CC_GREEN);
-    write_str(uart, "PASS!\n");
+    write_str(uart, "PASS!\r\n");
   } else {
     set_console_mode(uart, CC_RED);
-    write_str(uart, "FAIL!\n");
+    write_str(uart, "FAIL!\r\n");
   }
   set_console_mode(uart, CC_RESET);
 }

--- a/sw/cheri/tests/plic_tests.hh
+++ b/sw/cheri/tests/plic_tests.hh
@@ -80,10 +80,10 @@ struct PlicTest {
         if (plic_test->is_irq_clearable) {
           uart->interruptState = plic_test->ip_irq_id;
         } else {
-          uart->interrupt_disable(static_cast<OpenTitanUart::OpenTitanUartInterrupt>(plic_test->ip_irq_id));
           // Ensure that the `intr_test` bit does not keep the Status-type interrupt asserted.
           uart->interruptTest = 0;
         }
+        uart->interrupt_disable(static_cast<OpenTitanUart::OpenTitanUartInterrupt>(plic_test->ip_irq_id));
       };
       uart->interrupt_enable(uartMap[i].first.id);
       uart->interruptTest = ip_irq_id;
@@ -137,10 +137,10 @@ struct PlicTest {
         if (plic_test->is_irq_clearable) {
           i2c->interruptState = 0x1 << plic_test->ip_irq_id;
         } else {
-          i2c->interrupt_disable(static_cast<OpenTitanI2cInterrupt>(plic_test->ip_irq_id));
           // Ensure that the `intr_test` bit does not keep the Status-type interrupt asserted.
           i2c->interruptTest = 0;
         }
+        i2c->interrupt_disable(static_cast<OpenTitanI2cInterrupt>(plic_test->ip_irq_id));
       };
       i2c->interruptTest = 0x01 << ip_irq_id;
       wfi();

--- a/sw/cheri/tests/uart_tests.hh
+++ b/sw/cheri/tests/uart_tests.hh
@@ -42,7 +42,7 @@ bool uart_interrupt_state_test(UartPtr uart) {
   while (uart->interruptState & OpenTitanUart::InterruptTransmitWatermark) {
     uart->blocking_write('x');
     ++count;
-  };
+  }
 
   return count == 5;
 }


### PR DESCRIPTION
Ensure that `intr_test` for Status-type interrupts is cleared after using it within `PlicTest`, because otherwise subsequent tests may fail.
Helps `test_runner` run multiple times without an intervening system-global reset, and better supports test reordering.