### PR TITLE
SPI loopback, software reset and associated testing

### DIFF
--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -38,7 +38,7 @@ in {
     doCheck = true;
     buildInputs = [sonata-simulator pythonEnv];
     checkPhase = ''
-      python ${../util/test_runner.py} -t 60 sim \
+      python ${../util/test_runner.py} -t 120 sim \
           --elf-file ${sonata-system-software}/bin/test_runner
       echo "Test runner complete!"
       python ${../util/test_runner.py} -t 600 sim \

--- a/rtl/ip/spi/data/spi.hjson
+++ b/rtl/ip/spi/data/spi.hjson
@@ -116,6 +116,27 @@
       hwaccess: "hro",
       hwqe:     "true",
       fields: [
+        { bits: "31",
+          name: "SW_RESET",
+          desc: '''When a 1 is written to this field a reset of the controller logic
+                   is performed.
+                   This shall be used only to recover from error conditions.
+                   The TX FIFO shall be cleared before resetting the controller logic;
+                   then clear the RX FIFO after the controller reset.
+                   The bit self-clears and always reads as zero.'''
+          resval: "0",
+          swaccess: "wo",
+          hwaccess: "hro"
+        },
+        { bits: "30",
+          name: "INT_LOOPBACK",
+          desc: '''When set the CIPO line is internally connected to the COPI line,
+                   providing loopback functionality which may be useful in testing.
+                   Note that the COPI line is unaffected and still carries data so
+                   test software should normally leave the CS lines deasserted.
+                   This bit shall be changed only when the SPI core is idle.'''
+          resval: "0"
+        },
         { bits: "11:8",
           name: "RX_WATERMARK",
           desc: '''The watermark level for the receive FIFO, depending on the

--- a/rtl/ip/spi/rtl/spi.sv
+++ b/rtl/ip/spi/rtl/spi.sv
@@ -180,13 +180,24 @@ module spi import spi_reg_pkg::*; #(
   assign hw2reg.status.rx_fifo_empty.d = ~|rx_fifo_depth;
   assign hw2reg.status.idle.d          = spi_idle;
 
+  // Software reset of the core logic.
+  logic sw_reset;
+  assign sw_reset = reg2hw.control.sw_reset.qe & reg2hw.control.sw_reset.q;
+
+  // Internal loopback functionality allowing the input (CIPO) to be received directly from
+  // the output (COPI) for testing.
+  logic spi_cipo;
+  assign spi_cipo = reg2hw.control.int_loopback.q ? spi_copi_o : spi_cipo_i;
+
   spi_core u_spi_core (
     .clk_i,
     .rst_ni,
 
-    .data_in_i       (spi_data_in),
-    .data_in_valid_i (spi_data_in_valid),
-    .data_in_ready_o (spi_data_in_ready),
+    .sw_reset_i       (sw_reset),
+
+    .data_in_i        (spi_data_in),
+    .data_in_valid_i  (spi_data_in_valid),
+    .data_in_ready_o  (spi_data_in_ready),
 
     .data_out_o       (spi_data_out),
     .data_out_valid_o (spi_data_out_valid),
@@ -202,7 +213,7 @@ module spi import spi_reg_pkg::*; #(
     .half_clk_period_i(spi_half_clk_period),
 
     .spi_copi_o,
-    .spi_cipo_i,
+    .spi_cipo_i       (spi_cipo),
     .spi_clk_o
   );
 

--- a/rtl/ip/spi/rtl/spi_core.sv
+++ b/rtl/ip/spi/rtl/spi_core.sv
@@ -47,6 +47,8 @@ module spi_core #(
   input clk_i,
   input rst_ni,
 
+  input sw_reset_i,
+
   input  logic [7:0] data_in_i,
   input  logic       data_in_valid_i,
   output logic       data_in_ready_o,
@@ -268,6 +270,8 @@ module spi_core #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (~rst_ni) begin
+      state_q <= IDLE;
+    end else if (sw_reset_i) begin
       state_q <= IDLE;
     end else begin
       state_q <= state_d;

--- a/rtl/ip/spi/rtl/spi_reg_pkg.sv
+++ b/rtl/ip/spi/rtl/spi_reg_pkg.sv
@@ -92,6 +92,14 @@ package spi_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        q;
+      logic        qe;
+    } sw_reset;
+    struct packed {
+      logic        q;
+      logic        qe;
+    } int_loopback;
+    struct packed {
       logic [3:0]  q;
       logic        qe;
     } rx_watermark;
@@ -192,11 +200,11 @@ package spi_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_reg2hw_intr_state_reg_t intr_state; // [90:86]
-    spi_reg2hw_intr_enable_reg_t intr_enable; // [85:81]
-    spi_reg2hw_intr_test_reg_t intr_test; // [80:71]
-    spi_reg2hw_cfg_reg_t cfg; // [70:52]
-    spi_reg2hw_control_reg_t control; // [51:34]
+    spi_reg2hw_intr_state_reg_t intr_state; // [94:90]
+    spi_reg2hw_intr_enable_reg_t intr_enable; // [89:85]
+    spi_reg2hw_intr_test_reg_t intr_test; // [84:75]
+    spi_reg2hw_cfg_reg_t cfg; // [74:56]
+    spi_reg2hw_control_reg_t control; // [55:34]
     spi_reg2hw_start_reg_t start; // [33:22]
     spi_reg2hw_rx_fifo_reg_t rx_fifo; // [21:13]
     spi_reg2hw_tx_fifo_reg_t tx_fifo; // [12:4]
@@ -256,7 +264,7 @@ package spi_reg_pkg;
     4'b 0001, // index[ 1] SPI_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_INTR_TEST
     4'b 1111, // index[ 3] SPI_CFG
-    4'b 0011, // index[ 4] SPI_CONTROL
+    4'b 1111, // index[ 4] SPI_CONTROL
     4'b 0111, // index[ 5] SPI_STATUS
     4'b 0011, // index[ 6] SPI_START
     4'b 0001, // index[ 7] SPI_RX_FIFO

--- a/sw/cheri/common/sonata-devices.hh
+++ b/sw/cheri/common/sonata-devices.hh
@@ -56,7 +56,7 @@ typedef PLIC::SonataPlic *PlicPtr;
   CHERI::Capability<volatile SonataSpi> spi = root.cast<volatile SonataSpi>();
   assert(idx < SPI_NUM);
   spi.address() = SPI_ADDRESS + (idx * SPI_RANGE);
-  spi.bounds()  = UART_BOUNDS;
+  spi.bounds()  = SPI_BOUNDS;
   return spi;
 }
 


### PR DESCRIPTION
This PR consists of three commits:

1. An implementation of a loopback test using an external jumper wire on the RPi header (P19-P20) which could be installed in CI, although this is proof-of-concept and we probably want to use one of the other SPI connections since the RPi header is probably in use.
2. Implement an internal loopback mode in the SPI controller, to permit testing of all controllers in all modes (CPOL, CPHA, MSB_FIRST) and a software reset mechanism if - say - a command is started but not completed, and a block reset has not been/cannot be performed.
3. Test all of the SPI controllers using internal loopback, and all modes.

This has all been tested on FPGA; I suggest that once there's agreement on the physical practicalities w.r.t. CI we should enable a loopback test on a suitable connector. For now the RPi header-based external loopback test is excluded because the I2C testing uses the Sense HAT.