### PR TITLE
40 MHz Core clock

### DIFF
--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -9,7 +9,7 @@ module top_verilator (input logic clk_i, rst_ni);
   parameter bit DisableHyperram = 1'b0;
 
   // System clock frequency.
-  localparam int unsigned SysClkFreq = 30_000_000;
+  localparam int unsigned SysClkFreq = 40_000_000;
   // HyperRAM clock frequency.
   localparam int unsigned HRClkFreq  = 100_000_000;
   localparam int unsigned BaudRate   = 921_600;

--- a/nix/software.nix
+++ b/nix/software.nix
@@ -11,9 +11,9 @@
   cheriotRtosSource = pkgs.fetchFromGitHub {
     owner = "lowRISC";
     repo = "CHERIoT-RTOS";
-    rev = "c29bdeccc0335b81acea09c069fc94ca044a5a14";
+    rev = "bcd25c8734edb5395ac239b16af336987da45e9d";
     fetchSubmodules = true;
-    hash = "sha256-44xABnopOfF8TilGQNVTynfRc0cUiiAk7E5KoRZ0Hw0=";
+    hash = "sha256-UzvJyyavnWwg7XoF1C5LbVaFRm5Ib3V7Sy3Tl/Rmomg=";
   };
 
   reisfmtSource = pkgs.fetchFromGitHub {

--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -196,7 +196,7 @@ module top_sonata
   import sonata_pkg::*;
 
   // System clock frequency.
-  parameter int unsigned SysClkFreq = 30_000_000;
+  parameter int unsigned SysClkFreq = 40_000_000;
   parameter int unsigned HRClkFreq  = 100_000_000;
 
   parameter SRAMInitFile    = "";

--- a/sw/cheri/CMakeLists.txt
+++ b/sw/cheri/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 
 FetchContent_Declare(CHERIOT_RTOS
   GIT_REPOSITORY    https://github.com/lowRISC/CHERIoT-RTOS
-  GIT_TAG           c29bdeccc0335b81acea09c069fc94ca044a5a14
+  GIT_TAG           bcd25c8734edb5395ac239b16af336987da45e9d
 )
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)

--- a/sw/cheri/checks/revocation_test.cc
+++ b/sw/cheri/checks/revocation_test.cc
@@ -13,7 +13,7 @@
 
 using namespace CHERI;
 
-#define CPU_FREQ_HZ (30'000'000)
+#define CPU_FREQ_HZ (40'000'000)
 #include "../../common/defs.h"
 
 /**

--- a/sw/common/defs.h
+++ b/sw/common/defs.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#define CPU_TIMER_HZ (30'000'000)
+#define CPU_TIMER_HZ (40'000'000)
 #define BAUD_RATE (921'600)
 
 #define SRAM_ADDRESS (0x0010'0000)

--- a/sw/legacy/common/sonata_system.h
+++ b/sw/legacy/common/sonata_system.h
@@ -13,7 +13,7 @@
 #include "uart.h"
 
 // System Clock Frequency (Hz)
-#define SYSCLK_FREQ (30 * 1000 * 1000)
+#define SYSCLK_FREQ (40 * 1000 * 1000)
 
 #define UART_IRQ_NUM 16
 #define UART_IRQ (1 << UART_IRQ_NUM)


### PR DESCRIPTION
Increase `clk_sys` from 30 MHz to 40 MHz. Includes some physical-design-like tweaks to the Vivado flow to achieve timing closure at 40 MHz or possibly beyond.

See individual commit messages for further details.