### PR TITLE
Connect MicroSD card slot to an SPI controller

### DIFF
--- a/data/pins_sonata.xdc
+++ b/data/pins_sonata.xdc
@@ -289,6 +289,15 @@ set_property -dict { PACKAGE_PIN H6  IOSTANDARD LVCMOS18 } [get_ports ethmac_int
 set_property PULLTYPE PULLUP [get_ports ethmac_intr]
 set_property -dict { PACKAGE_PIN H5  IOSTANDARD LVCMOS18 } [get_ports ethmac_cs]
 
+## MicroSD card slot
+set_property -dict { PACKAGE_PIN U6  IOSTANDARD LVCMOS33 } [get_ports microsd_clk]
+set_property -dict { PACKAGE_PIN V4  IOSTANDARD LVCMOS33 } [get_ports microsd_dat0]
+# set_property -dict { PACKAGE_PIN R7  IOSTANDARD LVCMOS33 } [get_ports microsd_dat1] // unused in SPI bus mode
+# set_property -dict { PACKAGE_PIN V5  IOSTANDARD LVCMOS33 } [get_ports microsd_dat2] // unused in SPI bus mode
+set_property -dict { PACKAGE_PIN T8  IOSTANDARD LVCMOS33 } [get_ports microsd_dat3]
+set_property -dict { PACKAGE_PIN R8  IOSTANDARD LVCMOS33 } [get_ports microsd_cmd]
+set_property -dict { PACKAGE_PIN B3  IOSTANDARD LVCMOS18 } [get_ports microsd_det]
+
 # HyperRAM
 set_property -dict { PACKAGE_PIN   B1  IOSTANDARD   LVCMOS18 } [get_ports { hyperram_dq[0] }]
 set_property -dict { PACKAGE_PIN   E2  IOSTANDARD   LVCMOS18 } [get_ports { hyperram_dq[1] }]

--- a/data/top_config.toml
+++ b/data/top_config.toml
@@ -391,3 +391,16 @@ block_ios = [{block = "gpio", instance = 2, io = "ios", io_index = 0}]
 name = "pmod1"
 length = 8
 block_ios = [{block = "gpio", instance = 2, io = "ios", io_index = 8}]
+
+## MicroSD card slot
+[[pins]]
+name = "microsd_clk"
+block_ios = [{block = "spi", instance = 3, io = "sck"}]
+
+[[pins]]
+name = "microsd_dat0"
+block_ios = [{block = "spi", instance = 3, io = "rx"}]
+
+[[pins]]
+name = "microsd_cmd"
+block_ios = [{block = "spi", instance = 3, io = "tx"}]

--- a/doc/ip/gpio.md
+++ b/doc/ip/gpio.md
@@ -59,6 +59,7 @@ The only difference between the registers is that the latter has debounced signa
 
 | Bit offset | Description |
 |------------|-------------|
+| 17         | MicroSD card detection (0: present, 1: absent) |
 | 16-14      | Software select switches (1, 2, 3) |
 | 13         | mikroBUS interrupt |
 | 12-5       | DIP switches |

--- a/doc/ip/pinmux.md
+++ b/doc/ip/pinmux.md
@@ -92,6 +92,8 @@ The default value for all of these selectors is `'b10`.
 | 0x04d | `pmod1[5]` | 0, `gpio[2].ios[13]` |
 | 0x04e | `pmod1[6]` | 0, `gpio[2].ios[14]` |
 | 0x04f | `pmod1[7]` | 0, `gpio[2].ios[15]` |
+| 0x050 | `microsd_clk` | 0, `spi[3].sck` |
+| 0x051 | `microsd_cmd` | 0, `spi[3].tx` |
 
 Besides the output pin selectors, there are also selectors for which pin should drive block inputs:
 
@@ -105,7 +107,7 @@ Besides the output pin selectors, there are also selectors for which pin should 
 | 0x805 | `spi[0].rx` | 0, `appspi_d1` |
 | 0x806 | `spi[1].rx` | 0, 0 |
 | 0x807 | `spi[2].rx` | 0, `ethmac_cipo` |
-| 0x808 | `spi[3].rx` | 0, `rph_g9_cipo`, `ah_tmpio12` |
+| 0x808 | `spi[3].rx` | 0, `rph_g9_cipo`, `ah_tmpio12`, `microsd_dat0` |
 | 0x809 | `spi[4].rx` | 0, `rph_g19_cipo`, `mb3` |
 | 0x80a | `gpio[0].ios[0]` | 0, `rph_g0` |
 | 0x80b | `gpio[1].ios[0]` | 0, `ah_tmpio0` |

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -109,10 +109,12 @@ module top_verilator (input logic clk_i, rst_ni);
   wire ethmac_rst, ethmac_cs;
   // User LEDs.
   wire [7:0] usrLed;
+  // MicroSD card slot
+  wire microsd_dat3;
   // None of these signals is used presently.
   wire unused_io_ = ^{mb0, mb1, ah_tmpio10, rph_g18, rph_g17,
                       rph_g16_ce2, rph_g8_ce0, rph_g7_ce1, ethmac_rst, ethmac_cs,
-                      usrLed};
+                      usrLed, microsd_dat3};
 
   // Reporting of CHERI enable/disable and any exceptions that occur.
   wire  [CheriErrWidth-1:0] cheri_err;
@@ -202,16 +204,17 @@ module top_verilator (input logic clk_i, rst_ni);
   logic gp_ah_tmpio10, gp_mb1;
 
   // CS outputs to SPI peripherals from controllers.
-  assign appspi_cs   = spi_cs[0][0];
-  assign lcd_cs      = spi_cs[1][0];
-  assign ethmac_cs   = spi_cs[2][0];
-  assign rph_g8_ce0  = spi_cs[3][0];
-  assign rph_g7_ce1  = spi_cs[3][1];
-  assign ah_tmpio10  = spi_cs[3][2];
-  assign rph_g18     = spi_cs[4][0];
-  assign rph_g17     = spi_cs[4][1];
-  assign rph_g16_ce2 = spi_cs[4][2];
-  assign mb1         = spi_cs[4][3];
+  assign appspi_cs    = spi_cs[0][0];
+  assign lcd_cs       = spi_cs[1][0];
+  assign ethmac_cs    = spi_cs[2][0];
+  assign rph_g8_ce0   = spi_cs[3][0];
+  assign rph_g7_ce1   = spi_cs[3][1];
+  assign ah_tmpio10   = spi_cs[3][2];
+  assign microsd_dat3 = spi_cs[3][3];
+  assign rph_g18      = spi_cs[4][0];
+  assign rph_g17      = spi_cs[4][1];
+  assign rph_g16_ce2  = spi_cs[4][2];
+  assign mb1          = spi_cs[4][3];
 
   wire unused_gp_spi_cs_ = ^{gp_lcd_cs, gp_appspi_cs, gp_ethmac_cs,
                              gp_rph_g8_ce0, gp_rph_g7_ce1, gp_rph_g18, gp_rph_g17, gp_rph_g16_ce2,

--- a/rtl/system/pinmux.sv
+++ b/rtl/system/pinmux.sv
@@ -3951,6 +3951,102 @@ module pinmux
     .out_o(inout_to_pins_en_o[INOUT_PIN_PMOD1_7])
   );
 
+  logic [1:0] microsd_clk_sel;
+  logic microsd_clk_sel_addressed;
+
+  // Register addresses of 0x000 to 0x7ff are pin selectors, which are packed with 4 per 32-bit word.
+  assign microsd_clk_sel_addressed =
+    reg_addr[RegAddrWidth-1] == 1'b0 &
+    reg_addr[RegAddrWidth-2:0] == 80 &
+    reg_be[0] == 1'b1;
+
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      // Select second input by default so that pins are connected to the first block that is specified in the configuration.
+      microsd_clk_sel <= 2'b10;
+    end else begin
+      if (reg_we & microsd_clk_sel_addressed) begin
+        microsd_clk_sel <= reg_wdata[0+:2];
+      end
+    end
+  end
+
+  prim_onehot_mux #(
+    .Width(1),
+    .Inputs(2)
+  ) microsd_clk_mux (
+    .clk_i,
+    .rst_ni,
+    .in_i({
+      1'b0, // This is set to Z later when output enable is low.
+      spi_sck_i[3]
+    }),
+    .sel_i(microsd_clk_sel),
+    .out_o(out_to_pins_o[OUT_PIN_MICROSD_CLK])
+  );
+
+  prim_onehot_mux #(
+    .Width(1),
+    .Inputs(2)
+  ) microsd_clk_enable_mux (
+    .clk_i,
+    .rst_ni,
+    .in_i({
+      1'b0,
+      1'b1
+    }),
+    .sel_i(microsd_clk_sel),
+    .out_o(out_to_pins_en_o[OUT_PIN_MICROSD_CLK])
+  );
+
+  logic [1:0] microsd_cmd_sel;
+  logic microsd_cmd_sel_addressed;
+
+  // Register addresses of 0x000 to 0x7ff are pin selectors, which are packed with 4 per 32-bit word.
+  assign microsd_cmd_sel_addressed =
+    reg_addr[RegAddrWidth-1] == 1'b0 &
+    reg_addr[RegAddrWidth-2:0] == 80 &
+    reg_be[1] == 1'b1;
+
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      // Select second input by default so that pins are connected to the first block that is specified in the configuration.
+      microsd_cmd_sel <= 2'b10;
+    end else begin
+      if (reg_we & microsd_cmd_sel_addressed) begin
+        microsd_cmd_sel <= reg_wdata[8+:2];
+      end
+    end
+  end
+
+  prim_onehot_mux #(
+    .Width(1),
+    .Inputs(2)
+  ) microsd_cmd_mux (
+    .clk_i,
+    .rst_ni,
+    .in_i({
+      1'b0, // This is set to Z later when output enable is low.
+      spi_tx_i[3]
+    }),
+    .sel_i(microsd_cmd_sel),
+    .out_o(out_to_pins_o[OUT_PIN_MICROSD_CMD])
+  );
+
+  prim_onehot_mux #(
+    .Width(1),
+    .Inputs(2)
+  ) microsd_cmd_enable_mux (
+    .clk_i,
+    .rst_ni,
+    .in_i({
+      1'b0,
+      1'b1
+    }),
+    .sel_i(microsd_cmd_sel),
+    .out_o(out_to_pins_en_o[OUT_PIN_MICROSD_CMD])
+  );
+
   // Inputs - Physical pin inputs are muxed to particular block IO
 
   logic [1:0] uart_rx_0_sel;
@@ -4225,7 +4321,7 @@ module pinmux
     .out_o(spi_rx_o[2])
   );
 
-  logic [2:0] spi_rx_3_sel;
+  logic [3:0] spi_rx_3_sel;
   logic spi_rx_3_sel_addressed;
 
   // Register addresses of 0x800 to 0xfff are block IO selectors, which are packed with 4 per 32-bit word.
@@ -4237,24 +4333,25 @@ module pinmux
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       // Select second input by default so that pins are connected to the first block that is specified in the configuration.
-      spi_rx_3_sel <= 3'b10;
+      spi_rx_3_sel <= 4'b10;
     end else begin
       if (reg_we & spi_rx_3_sel_addressed) begin
-        spi_rx_3_sel <= reg_wdata[0+:3];
+        spi_rx_3_sel <= reg_wdata[0+:4];
       end
     end
   end
 
   prim_onehot_mux #(
     .Width(1),
-    .Inputs(3)
+    .Inputs(4)
   ) spi_rx_3_mux (
     .clk_i,
     .rst_ni,
     .in_i({
       1'b0,
       inout_from_pins_i[INOUT_PIN_RPH_G9_CIPO],
-      inout_from_pins_i[INOUT_PIN_AH_TMPIO12]
+      inout_from_pins_i[INOUT_PIN_AH_TMPIO12],
+      in_from_pins_i[IN_PIN_MICROSD_DAT0]
     }),
     .sel_i(spi_rx_3_sel),
     .out_o(spi_rx_o[3])

--- a/rtl/system/sonata_pkg.sv
+++ b/rtl/system/sonata_pkg.sv
@@ -13,8 +13,8 @@ package sonata_pkg;
 
   localparam int unsigned SPI_CS_NUM = 4;
 
-  localparam int unsigned IN_PIN_NUM = 7;
-  localparam int unsigned OUT_PIN_NUM = 12;
+  localparam int unsigned IN_PIN_NUM = 8;
+  localparam int unsigned OUT_PIN_NUM = 14;
   localparam int unsigned INOUT_PIN_NUM = 68;
 
   localparam int unsigned IN_PIN_SER0_RX = 0;
@@ -24,6 +24,7 @@ package sonata_pkg;
   localparam int unsigned IN_PIN_ETHMAC_CIPO = 4;
   localparam int unsigned IN_PIN_MB3 = 5;
   localparam int unsigned IN_PIN_MB8 = 6;
+  localparam int unsigned IN_PIN_MICROSD_DAT0 = 7;
 
   localparam int unsigned OUT_PIN_SER0_TX = 0;
   localparam int unsigned OUT_PIN_SER1_TX = 1;
@@ -37,6 +38,8 @@ package sonata_pkg;
   localparam int unsigned OUT_PIN_MB2 = 9;
   localparam int unsigned OUT_PIN_MB4 = 10;
   localparam int unsigned OUT_PIN_MB7 = 11;
+  localparam int unsigned OUT_PIN_MICROSD_CLK = 12;
+  localparam int unsigned OUT_PIN_MICROSD_CMD = 13;
 
   localparam int unsigned INOUT_PIN_SCL0 = 0;
   localparam int unsigned INOUT_PIN_SDA0 = 1;


### PR DESCRIPTION
Wire up the on-board MicroSD card slot to an existing SPI controller via pinmux.
CS line is connected at top-level.
Card detection is connected to fixed GPI.

As-yet untested.