### PR TITLE
Bump CHERIoT RTOS version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -174,9 +174,9 @@
       cheriotRtosSource = pkgs.fetchFromGitHub {
         owner = "lowRISC";
         repo = "CHERIoT-RTOS";
-        rev = "043721196e8ad7260a10799b2fb5df1d2b534a80";
+        rev = "5668b9afd5d55ee750eed6077f72d3c2a6f35234";
         fetchSubmodules = true;
-        hash = "sha256-lWoQVaF1CVS6KAyTqWaY7H+505qJ2vzlZB4TlMZbuPo=";
+        hash = "sha256-u1yzvSj717AX2fY2C9zKRERBPCCcsNW6NaZpWac5DAg=";
       };
 
       sonata-system-software = pkgs.stdenv.mkDerivation rec {

--- a/sw/cheri/CMakeLists.txt
+++ b/sw/cheri/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 
 FetchContent_Declare(CHERIOT_RTOS
   GIT_REPOSITORY    https://github.com/lowRISC/CHERIoT-RTOS
-  GIT_TAG           043721196e8ad7260a10799b2fb5df1d2b534a80
+  GIT_TAG           5668b9afd5d55ee750eed6077f72d3c2a6f35234
 )
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)


### PR DESCRIPTION
This will bring sonata-software and sonata-system in line with each other to use the same CHERIoT-RTOS commit (at the time I make this PR)