### PR TITLE
Add phys-based timing optimisations

### DIFF
--- a/flow/vivado_hook_opt_design_post.tcl
+++ b/flow/vivado_hook_opt_design_post.tcl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Optional additional logic optimisation
+if {$opt >= 2} {
+  # Perform further logic optimisation to improve the timing fixing ability
+  # of post-route phys_opt_design optimisation. May make timing worse
+  # before post-route optimisation hopefully makes it better.
+  opt_design -directive ExploreWithRemap
+}

--- a/flow/vivado_hook_opt_design_pre.tcl
+++ b/flow/vivado_hook_opt_design_pre.tcl
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Set optimisation level for use in this hook and others later on.
+# - Set `opt` to `0` for no extra optimisation (fusesoc Vivado default).
+# - Set `opt` to `1` for light & effective extra optimisation (general use).
+# - Set `opt` to `2` for heavy & chancy extra optimisation (pushing clk speed).
+set opt 1
+
+if {$opt >= 1} {
+  # Over-constrain clock used by the core during early implementation stages
+  # to avoid/reduce post-route timing violations. Clear before route_design.
+  #
+  # Over-constraining works by making the tool work a bit harder to optimise
+  # tight timing paths early on in the implementation flow. This is most
+  # useful when the tool is under-estimating the future routing delay on
+  # these paths, as can often happen in congested designs. Over-constraining
+  # can also help post-route optimisation by improving timing in the wider
+  # design, giving the optimiser less to fix and more paths that can tolerate
+  # being adversely modified in order to improve the critical path. Note that
+  # over-constraining too much can lead to increased runtime and worse timing
+  # due to over-loading the tool.
+  set_clock_uncertainty -setup 0.8 [get_clocks clk_sys]
+}

--- a/flow/vivado_hook_route_design_post.tcl
+++ b/flow/vivado_hook_route_design_post.tcl
@@ -1,0 +1,29 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Optional post-route optimisation
+if {$opt >= 1} {
+  # Post-route optimisation that can fix small (~0.6 ns) timing failures
+  # at the cost of up to a few minutes additional runtime.
+  #
+  # From UG904: RuntimeOptimized
+  #   Provides a reduced set of physical optimizations with the shortest
+  #   runtime. Use this directive when compile time reduction is more important
+  #   than design performance. RuntimeOptimized includes fanout_opt,
+  #   critical_cell_opt, placement_opt, and bram_enable_opt.
+  phys_opt_design -directive RuntimeOptimized
+}
+if {$opt >= 2} {
+  # Additional post-route optimisation that can help fix any remaining
+  # timing failures at the cost of up to several minutes additional runtime.
+  #
+  # From UG904: AggressiveExplore
+  #   Similar to Explore but with different optimization algorithms and
+  #   more aggressive goals. Includes a SLR crossing optimization phase that
+  #   is allowed to degrade WNS which should be regained in subsequent
+  #   optimization algorithms. Also includes a hold violation fixing
+  #   optimization.
+  # Appears to use different algorithm/optimisations from RuntimeOptimized.
+  phys_opt_design -directive AggressiveExplore
+}

--- a/flow/vivado_hook_route_design_pre.tcl
+++ b/flow/vivado_hook_route_design_pre.tcl
@@ -1,0 +1,6 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Clear clock over-constraint for the routing stage
+set_clock_uncertainty -setup 0 [get_clocks clk_sys]

--- a/flow/vivado_setup.tcl
+++ b/flow/vivado_setup.tcl
@@ -14,3 +14,22 @@
 # Note: `file_type` must be set before `used_in_synthesis`.
 set_property file_type Tcl [get_files impl_timing.xdc]
 set_property used_in_synthesis false [get_files impl_timing.xdc]
+
+# Setup hook scripts, to be called at various stages during the build process
+# See Xilinx UG 894 ("Using Tcl Scripting") for documentation.
+#
+# fusesoc-generated workroot containing the Vivado project file
+set workroot [pwd]
+# Register custom hooks - must also be added to .core file
+# set_property STEPS.SYNTH_DESIGN.TCL.PRE     "${workroot}/vivado_hook_synth_design_pre.tcl"     [get_runs synth_1]
+# set_property STEPS.SYNTH_DESIGN.TCL.POST    "${workroot}/vivado_hook_synth_design_post.tcl"    [get_runs synth_1]
+set_property STEPS.OPT_DESIGN.TCL.PRE       "${workroot}/vivado_hook_opt_design_pre.tcl"       [get_runs impl_1]
+set_property STEPS.OPT_DESIGN.TCL.POST      "${workroot}/vivado_hook_opt_design_post.tcl"      [get_runs impl_1]
+# set_property STEPS.PLACE_DESIGN.TCL.PRE     "${workroot}/vivado_hook_place_design_pre.tcl"     [get_runs impl_1]
+# set_property STEPS.PLACE_DESIGN.TCL.POST    "${workroot}/vivado_hook_place_design_post.tcl"    [get_runs impl_1]
+# set_property STEPS.PHYS_OPT_DESIGN.TCL.PRE  "${workroot}/vivado_hook_phys_opt_design_pre.tcl"  [get_runs impl_1]
+# set_property STEPS.PHYS_OPT_DESIGN.TCL.POST "${workroot}/vivado_hook_phys_opt_design_post.tcl" [get_runs impl_1]
+set_property STEPS.ROUTE_DESIGN.TCL.PRE     "${workroot}/vivado_hook_route_design_pre.tcl"     [get_runs impl_1]
+set_property STEPS.ROUTE_DESIGN.TCL.POST    "${workroot}/vivado_hook_route_design_post.tcl"    [get_runs impl_1]
+# set_property STEPS.WRITE_BITSTREAM.TCL.PRE  "${workroot}/vivado_hook_write_bitstream_pre.tcl"  [get_runs impl_1]
+# set_property STEPS.WRITE_BITSTREAM.TCL.POST "${workroot}/vivado_hook_write_bitstream_post.tcl" [get_runs impl_1]

--- a/sonata.core
+++ b/sonata.core
@@ -64,6 +64,10 @@ filesets:
   files_tcl:
     files:
       - flow/vivado_setup.tcl : { file_type: tclSource }
+      - flow/vivado_hook_opt_design_pre.tcl : { file_type: user, copyto: vivado_hook_opt_design_pre.tcl }
+      - flow/vivado_hook_opt_design_post.tcl : { file_type: user, copyto: vivado_hook_opt_design_post.tcl }
+      - flow/vivado_hook_route_design_pre.tcl : { file_type: user, copyto: vivado_hook_route_design_pre.tcl }
+      - flow/vivado_hook_route_design_post.tcl : { file_type: user, copyto: vivado_hook_route_design_post.tcl }
 
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1


### PR DESCRIPTION
Add flow hooks to implement some optional timing optimisations:
- Add timing margin to clk_sys for early implementation stages. This allows faster clk_sys speeds w/o much additional runtime.
- Add optional additional logic optimisation.
- Add two levels of post-route optimisation commands. This allows even faster clk_sys speeds at the cost of added runtime.

All these optimisations are controlled by an `opt` TCL variable set in the hook that is first called in the implementation flow.