### PR TITLE
Update CHERIoT RTOS source and tests to use updated I2C driver

### DIFF
--- a/nix/software.nix
+++ b/nix/software.nix
@@ -11,9 +11,9 @@
   cheriotRtosSource = pkgs.fetchFromGitHub {
     owner = "lowRISC";
     repo = "CHERIoT-RTOS";
-    rev = "34fc63bd6f11ba747b2e98e49f40eb5949809682";
+    rev = "c29bdeccc0335b81acea09c069fc94ca044a5a14";
     fetchSubmodules = true;
-    hash = "sha256-sN0tkHTQBYUFs+5Ia83aTXzEvn5LiR+QCbeOcYy5eDk=";
+    hash = "sha256-44xABnopOfF8TilGQNVTynfRc0cUiiAk7E5KoRZ0Hw0=";
   };
 in {
   sonata-system-software = pkgs.stdenv.mkDerivation rec {

--- a/sw/cheri/CMakeLists.txt
+++ b/sw/cheri/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 
 FetchContent_Declare(CHERIOT_RTOS
   GIT_REPOSITORY    https://github.com/lowRISC/CHERIoT-RTOS
-  GIT_TAG           34fc63bd6f11ba747b2e98e49f40eb5949809682
+  GIT_TAG           c29bdeccc0335b81acea09c069fc94ca044a5a14
 )
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)

--- a/sw/cheri/tests/i2c_tests.hh
+++ b/sw/cheri/tests/i2c_tests.hh
@@ -197,7 +197,9 @@ int i2c_rpi_hat_id_eeprom_test(I2cPtr i2c) {
 
   // Send two 0x0000 byte addresses and skip the STOP condition.
   const uint8_t addr[] = {0, 0};
-  i2c->blocking_write(RpiHatIdEepromAddr, addr, sizeof(addr), true);
+  if (!i2c->blocking_write(RpiHatIdEepromAddr, addr, sizeof(addr), true)) {
+    return ++failures;  // If we can't write, then the read will block.
+  }
 
   // Fill a read buffer with dummy data so that we see changes.
   constexpr uint8_t DummyReadVal = 0x3D;
@@ -247,7 +249,9 @@ int i2c_rpi_hat_imu_whoami_test(I2cPtr i2c) {
 
   // Send the address and skip the STOP condition.
   const uint8_t addr[] = {RpiHatWhoAmIRegAddr};
-  i2c->blocking_write(RpiHatAccelGyroWhoAmIAddr, addr, sizeof(addr), true);
+  if (!i2c->blocking_write(RpiHatAccelGyroWhoAmIAddr, addr, sizeof(addr), true)) {
+    return ++failures;  // If we can't write, then the read will block.
+  }
 
   // Read from the `WHO_AM_I` register of the Accelerometer & Gyroscope,
   // and check it matches the expected value.
@@ -257,7 +261,9 @@ int i2c_rpi_hat_imu_whoami_test(I2cPtr i2c) {
   }
 
   // Send one 0x0F byte address and skip the STOP condition.
-  i2c->blocking_write(RpiHatIdMagneticWhoAmIAddr, addr, sizeof(addr), true);
+  if (!i2c->blocking_write(RpiHatIdMagneticWhoAmIAddr, addr, sizeof(addr), true)) {
+    return ++failures;  // If we can't write, then the read will block.
+  }
 
   // Read from the `WHO_AM_I` register of the Magnetic Sensor, and check
   // it matches the expected value.
@@ -287,7 +293,9 @@ int i2c_as6212_temperature_sense_test(I2cPtr i2c) {
 
   // Read from the config register, and check the dummy data was modified.
   uint8_t addr[] = {As6212ConfigRegAddr};
-  i2c->blocking_write(As6212Addr, addr, sizeof(addr), false);
+  if (!i2c->blocking_write(As6212Addr, addr, sizeof(addr), false)) {
+    return ++failures;  // If we can't write, then the read will block.
+  }
   uint8_t data[2] = {0xF0, 0x0F};
   if (!i2c->blocking_read(As6212Addr, data, 2U) || data[0] == 0xF0) {
     failures++;
@@ -295,7 +303,9 @@ int i2c_as6212_temperature_sense_test(I2cPtr i2c) {
 
   // Read from the temperature register
   addr[0] = As6212TempRegAddr;
-  i2c->blocking_write(As6212Addr, addr, sizeof(addr), false);
+  if (!i2c->blocking_write(As6212Addr, addr, sizeof(addr), false)) {
+    return ++failures;  // If we can't write, then the read will block.
+  }
   if (!i2c->blocking_read(As6212Addr, data, 2U)) {
     failures++;
   }

--- a/sw/cheri/tests/plic_tests.hh
+++ b/sw/cheri/tests/plic_tests.hh
@@ -90,7 +90,6 @@ struct PlicTest {
     };
     static constexpr std::array<i2c_irq, 15> i2cMap = {{
         {OpenTitanI2cInterrupt::ReceiveOverflow, true},
-        {OpenTitanI2cInterrupt::Nak, true},
         {OpenTitanI2cInterrupt::SclInterference, true},
         {OpenTitanI2cInterrupt::SdaInterference, true},
         {OpenTitanI2cInterrupt::StretchTimeout, true},
@@ -99,6 +98,7 @@ struct PlicTest {
         {OpenTitanI2cInterrupt::UnexpectedStop, true},
         {OpenTitanI2cInterrupt::HostTimeout, true},
 
+        {OpenTitanI2cInterrupt::ControllerHalt, false},
         {OpenTitanI2cInterrupt::TransmitStretch, false},
         {OpenTitanI2cInterrupt::AcquiredFull, false},
         {OpenTitanI2cInterrupt::TransmitThreshold, false},


### PR DESCRIPTION
More detailed info in the commit messages.

See [here](https://github.com/lowRISC/cheriot-rtos/compare/34fc63bd6f11ba747b2e98e49f40eb5949809682...lowRISC:cheriot-rtos:c29bdeccc0335b81acea09c069fc94ca044a5a14) for the change in the CHERIoT RTOS source being used, which only contains commits from https://github.com/lowRISC/cheriot-rtos/pull/16.

This PR simply updates the CHERIoT RTOS source, and then makes small changes to the PLIC and I2C tests so that they continue working in the same way with the driver updates. The driver updates that need to be handled are the change of the `Nack` I2C interrupt to a `ControllerHalt` interrupt, and that the `blocking_write` function now returns a result that must be appropriately checked. 

This functionality is blocking the Pinmux test and check procedure from working properly after the IP block was updated.