### PR TITLE
Add MicroSD pins to Pinmux Driver

### DIFF
--- a/sw/cheri/common/platform-pinmux.hh
+++ b/sw/cheri/common/platform-pinmux.hh
@@ -134,6 +134,8 @@ class SonataPinmux : private utils::NoCopyNoMove {
     Pmod1Io8               = 0x04d,  // pmod1_5,      i.e. PMOD1.8
     Pmod1Io9               = 0x04e,  // pmod1_6,      i.e. PMOD1.9
     Pmod1Io10              = 0x04f,  // pmod1_7,      i.e. PMOD1.10
+    MicroSdClock           = 0x050,  // microsd_clk   i.e. SD1.CLK
+    MicroSdCommand         = 0x051,  // microsd_cmd   i.e. SD1.CMD
   };
 
   /**
@@ -300,6 +302,7 @@ class SonataPinmux : private utils::NoCopyNoMove {
   static constexpr uint8_t block_input_options(BlockInput block_input) {
     switch (block_input) {
       case BlockInput::SpiReceive3:
+        return 4;
       case BlockInput::SpiReceive4:
         return 3;
       default:


### PR DESCRIPTION
This PR updates the Pinmux driver so that it is no longer out of date with the most recent pinmux changes that introduce the MicroSD card (see #239). This involves adding two more output pin registers for the MicroSD clock & command pins, and allowing the Spi3 Receive to have 1 more value selected (i.e. the MicroSD Dat0). Specifically see the changes to `pinmux.md` in 8c8d34961891770537a4af93767d8b3ab7448b45 to understand why the changes in this PR have been made.