### PR TITLE
Expand both checking and logging of IRQs

### DIFF
--- a/util/test_runner.py
+++ b/util/test_runner.py
@@ -256,7 +256,6 @@ def watch_output(config: Config) -> None:
         if FAILED_MESSAGE in line:
             return_code.put(ReturnCode.TESTS_FAILED)
             break
-        time.sleep(TICK_SECONDS)
 
 
 def watchdog(config: Config) -> None:


### PR DESCRIPTION
Present logging information about the IP-level interrupt state, since this is more useful in the event of a failure.

Extend the IP-level interrupt state testing for SPI and USBDEV since this was incomplete.