### PR TITLE
Update Verilator top level and I2C DPI models to match Sonata board

### DIFF
--- a/dv/dpi/i2cdpi/i2cdpi.hh
+++ b/dv/dpi/i2cdpi/i2cdpi.hh
@@ -4,6 +4,7 @@
 
 #ifndef __DV_DPI_I2CDPI_I2CDPI_H_
 #define __DV_DPI_I2CDPI_I2CDPI_H_
+#include <assert.h>
 #include <map>
 #include "i2cdevice.hh"
 
@@ -36,6 +37,8 @@ public:
 
   // Add a device to this bus.
   void add_device(i2cdevice *dev) {
+    assert(dev);
+    logText(" - adding device at address 0x%02x\n", dev->getAddress());
     (void)devs.insert(std::pair<i2caddr_t, i2cdevice *>(dev->getAddress(), dev));
   }
 


### PR DESCRIPTION
The two DPI models did not model the post-pinmux changes to the I2C buses; there are no longer just two physical I2C buses electrically commoned within the FPGA.

Separate the I2C devices into three I2C DPI models representing the physical buses that have devices at present. Tie the other I2C buses inactive, modelling the pullups on the FPGA board.

Modify `i2cdpi` so that it properly handles traffic to an address at which there is no connected device.