### PR TITLE
Address comments from Pinmux Test PR

### DIFF
--- a/sw/cheri/common/console.hh
+++ b/sw/cheri/common/console.hh
@@ -13,6 +13,7 @@
 #define CC_BOLD "1"
 #define CC_RED "31"
 #define CC_GREEN "32"
+#define CC_PURPLE "35"
 #define CC_RESET "0"
 
 struct WriteUart {

--- a/sw/cheri/common/sonata-devices.hh
+++ b/sw/cheri/common/sonata-devices.hh
@@ -18,6 +18,7 @@
 #include <platform-i2c.hh>
 #include <platform-spi.hh>
 #include <platform-usbdev.hh>
+#include "platform-pinmux.hh"
 
 typedef CHERI::Capability<void> CapRoot;
 typedef volatile SonataGPIO *GpioPtr;
@@ -28,6 +29,7 @@ typedef volatile SonataSpi *SpiPtr;
 typedef volatile OpenTitanUsbdev *UsbdevPtr;
 typedef volatile uint32_t *HyperramPtr;
 typedef PLIC::SonataPlic *PlicPtr;
+typedef SonataPinmux *PinmuxPtr;
 
 [[maybe_unused]] static GpioPtr gpio_ptr(CapRoot root) {
   CHERI::Capability<volatile SonataGPIO> gpio = root.cast<volatile SonataGPIO>();

--- a/sw/cheri/tests/pinmux_tests.hh
+++ b/sw/cheri/tests/pinmux_tests.hh
@@ -57,6 +57,10 @@ static constexpr uint8_t PmxToDisabled = 0;
 static int spi_jedec_id_test(Capability<volatile SonataSpi> spi, SpiFlash spi_flash) {
   int failures = 0;
 
+  // Configure the SPI to be MSB-first.
+  spi->wait_idle();
+  spi->init(false, false, true, 0);
+
   // Read the JEDEC ID from Flash
   uint8_t jedec_id[3] = {0};
   spi_flash.read_jedec_id(jedec_id);
@@ -378,9 +382,10 @@ void pinmux_tests(CapRoot root, Log &log) {
 
   // Execute the specified number of iterations of each test.
   for (size_t i = 0; i < PINMUX_TEST_ITERATIONS; i++) {
-    log.println("running pinmux_test: {} \\ {}", i, PINMUX_TEST_ITERATIONS - 1);
-    log.println("\x1b[35m(may need manual pin connections to pass)");
-    log.println("\x1b[0m\r\n");
+    log.println("\r\nrunning pinmux_test: {} \\ {}", i, PINMUX_TEST_ITERATIONS - 1);
+    set_console_mode(log, CC_PURPLE);
+    log.println("(may need manual pin connections to pass)");
+    set_console_mode(log, CC_RESET);
 
     bool test_failed = false;
     int failures     = 0;

--- a/sw/cheri/tests/pinmux_tests.hh
+++ b/sw/cheri/tests/pinmux_tests.hh
@@ -94,25 +94,25 @@ static int pinmux_uart_test(SonataPinmux *pinmux, ds::xoroshiro::P32R8 &prng, Ua
   int failures = 0;
 
   // Mux UART3 over mikroBus P7 RX & TX via default.
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::mb7, PmxMikroBusUartTransmitToUartTx3)) failures++;
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxUartReceive3ToMb8)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::mb7, PmxMikroBusUartTransmitToUartTx3);
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxUartReceive3ToMb8);
 
   // Check that messages are sent and received via UART3
-  if (!uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes)) failures++;
+  failures += !uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes);
 
   // Disable UART3 TX through pinmux, and check the test now fails (no TX sent)
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::mb7, PmxToDisabled)) failures++;
-  if (uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::mb7, PmxToDisabled);
+  failures += uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes);
 
   // Re-enable UART3 TX and disable UART3 RX through pinmux, and check that the test
   // still fails (no RX received)
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::mb7, PmxMikroBusUartTransmitToUartTx3)) failures++;
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxToDisabled)) failures++;
-  if (uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::mb7, PmxMikroBusUartTransmitToUartTx3);
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxToDisabled);
+  failures += uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes);
 
   // Re-enable UART3 RX and check the test now passes again
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxUartReceive3ToMb8)) failures++;
-  if (!uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes)) failures++;
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxUartReceive3ToMb8);
+  failures += !uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes);
 
   return failures;
 }
@@ -132,9 +132,9 @@ static int pinmux_spi_flash_test(SonataPinmux *pinmux, Capability<volatile Sonat
   int failures = 0;
 
   // Ensure the SPI Flash pins are enabled using Pinmux
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_d0, PmxSpiFlashDataToSpiTx0)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_clk, PmxSpiFlashClockToSpiClk0)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxSpiFlashCsToSpiCs0)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_d0, PmxSpiFlashDataToSpiTx0);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_clk, PmxSpiFlashClockToSpiClk0);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxSpiFlashCsToSpiCs0);
 
   // Configure the SPI to be MSB-first.
   spi->wait_idle();
@@ -146,19 +146,19 @@ static int pinmux_spi_flash_test(SonataPinmux *pinmux, Capability<volatile Sonat
 
   // Disable the SPI Flash pins through pinmux
   spi->wait_idle();
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxToDisabled)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_d0, PmxToDisabled)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_clk, PmxToDisabled)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxToDisabled);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_d0, PmxToDisabled);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_clk, PmxToDisabled);
   spi_flash.reset();
 
   // Run the JEDEC ID Test again; we expect it to fail.
-  if (spi_jedec_id_test(spi, spi_flash) == 0) failures++;
+  failures += (spi_jedec_id_test(spi, spi_flash) == 0);
 
   // Re-enable the SPI Flash pins through pinmux
   spi->wait_idle();
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_d0, PmxSpiFlashDataToSpiTx0)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_clk, PmxSpiFlashClockToSpiClk0)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxSpiFlashCsToSpiCs0)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_d0, PmxSpiFlashDataToSpiTx0);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_clk, PmxSpiFlashClockToSpiClk0);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxSpiFlashCsToSpiCs0);
   spi_flash.reset();
 
   // Run the JEDEC ID Test one more time; it should pass.
@@ -166,15 +166,15 @@ static int pinmux_spi_flash_test(SonataPinmux *pinmux, Capability<volatile Sonat
 
   // Disable specifically the Chip Select through Pinmux.
   spi->wait_idle();
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxToDisabled)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxToDisabled);
   spi_flash.reset();
 
   // Run the JEDEC ID Test again; we expect it to fail.
-  if (spi_jedec_id_test(spi, spi_flash) == 0) failures++;
+  failures += (spi_jedec_id_test(spi, spi_flash) == 0);
 
   // Re-enable the Chip Select through Pinmux.
   spi->wait_idle();
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxSpiFlashCsToSpiCs0)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::appspi_cs, PmxSpiFlashCsToSpiCs0);
   spi_flash.reset();
 
   // Run the JEDEC ID Test again; it should pass.
@@ -203,10 +203,10 @@ static int pinmux_i2c_test(SonataPinmux *pinmux, I2cPtr i2c0, I2cPtr i2c1) {
   int failures = 0;
 
   // Ensure the RPI Hat I2C pins are enabled via Pinmux
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g0, PmxRPiHat27ToI2cSda0)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g1, PmxRPiHat28ToI2cScl0)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g2_sda, PmxRPiHat3ToI2cSda1)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g3_scl, PmxRPiHat5ToI2cScl1)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g0, PmxRPiHat27ToI2cSda0);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g1, PmxRPiHat28ToI2cScl0);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g2_sda, PmxRPiHat3ToI2cSda1);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g3_scl, PmxRPiHat5ToI2cScl1);
 
   // Run the normal I2C RPI Hat ID_EEPROM and WHO_AM_I tests
   failures += i2c_rpi_hat_id_eeprom_test(i2c0);
@@ -214,25 +214,25 @@ static int pinmux_i2c_test(SonataPinmux *pinmux, I2cPtr i2c0, I2cPtr i2c1) {
 
   // Disable the RPI Hat I2C0 output pins, and check that the ID EEPROM test
   // now fails (and the WHOAMI test still succeeds).
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g0, PmxToDisabled)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g1, PmxToDisabled)) failures++;
-  if (i2c_rpi_hat_id_eeprom_test(i2c0) == 0) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g0, PmxToDisabled);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g1, PmxToDisabled);
+  failures += (i2c_rpi_hat_id_eeprom_test(i2c0) == 0);
   failures += i2c_rpi_hat_imu_whoami_test(i2c1);
 
   // Re-enables the RPI Hat I2C0 pins and disables the I2C1 pins, and check that the
   // ID EEPROM test now passes. and the WHOAMI test now fails.
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g0, PmxRPiHat27ToI2cSda0)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g1, PmxRPiHat28ToI2cScl0)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g2_sda, PmxToDisabled)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g3_scl, PmxToDisabled)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g0, PmxRPiHat27ToI2cSda0);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g1, PmxRPiHat28ToI2cScl0);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g2_sda, PmxToDisabled);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g3_scl, PmxToDisabled);
   reset_i2c_controller(i2c0);
   failures += i2c_rpi_hat_id_eeprom_test(i2c0);
-  if (i2c_rpi_hat_imu_whoami_test(i2c1) == 0) failures++;
+  failures += (i2c_rpi_hat_imu_whoami_test(i2c1) == 0);
 
   // Re-enables both the RPI Hat I2C0 and I2C1 pins via pinmux, and checks that both
   // tests now pass again.
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g2_sda, PmxRPiHat3ToI2cSda1)) failures++;
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g3_scl, PmxRPiHat5ToI2cScl1)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g2_sda, PmxRPiHat3ToI2cSda1);
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::rph_g3_scl, PmxRPiHat5ToI2cScl1);
   reset_i2c_controller(i2c1);
   failures += i2c_rpi_hat_id_eeprom_test(i2c0);
   failures += i2c_rpi_hat_imu_whoami_test(i2c1);
@@ -263,21 +263,21 @@ static int pinmux_gpio_test(SonataPinmux *pinmux, SonataGpioFull *gpio) {
   set_gpio_output_enable(gpio, GpioPinInput, false);
 
   // Ensure the GPIO (Arduino Shield D8 & D9) are enabled via Pinmux
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio8, PmxArduinoD8ToGpios_1_8)) failures++;
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::gpio_1_ios_9, PmxArduinoGpio9ToAhTmpio9)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio8, PmxArduinoD8ToGpios_1_8);
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::gpio_1_ios_9, PmxArduinoGpio9ToAhTmpio9);
 
   // Check that reading & writing from/to GPIO works as expected.
-  if (!gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength)) failures++;
+  failures += !gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength);
 
   // Disable the GPIO via pinmux, and check that the test now fails.
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio8, PmxToDisabled)) failures++;
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::gpio_1_ios_9, PmxToDisabled)) failures++;
-  if (gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio8, PmxToDisabled);
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::gpio_1_ios_9, PmxToDisabled);
+  failures += gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength);
 
   // Re-enable the GPIO via pinmux, and check that the test passes once more
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio8, PmxArduinoD8ToGpios_1_8)) failures++;
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::gpio_1_ios_9, PmxArduinoGpio9ToAhTmpio9)) failures++;
-  if (!gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio8, PmxArduinoD8ToGpios_1_8);
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::gpio_1_ios_9, PmxArduinoGpio9ToAhTmpio9);
+  failures += !gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength);
 
   return failures;
 }
@@ -310,28 +310,28 @@ static int pinmux_mux_test(SonataPinmux *pinmux, ds::xoroshiro::P32R8 &prng, Uar
   set_gpio_output_enable(gpio, GpioPinInput, false);
 
   // Mux UART3 over Arduino Shield D0 (RX) & D1 (TX)
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio1, PmxArduinoD1ToUartTx3)) failures++;
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxUartReceive3ToAhTmpio0)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio1, PmxArduinoD1ToUartTx3);
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxUartReceive3ToAhTmpio0);
 
   // Test that UART3 works over the muxed Arduino Shield D0 & D1 pins,
   // and that GPIO does not work, as these pins are not muxed for GPIO.
-  if (!uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes)) failures++;
-  if (gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength)) failures++;
+  failures += !uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes);
+  failures += gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength);
 
   // Mux GPIO over Arduino Shield D0 (GPIO input) & D1 (GPIO output)
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio1, PmxArduinoD1ToGpio_1_1)) failures++;
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::gpio_1_ios_0, PmxArduinoGpio0ToAhTmpio0)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio1, PmxArduinoD1ToGpio_1_1);
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::gpio_1_ios_0, PmxArduinoGpio0ToAhTmpio0);
 
   // Test that UART3 no longer works (no longer muxed over D0 & D1),
   // and that our muxed GPIO now works.
-  if (uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes)) failures++;
-  if (!gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength)) failures++;
+  failures += uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes);
+  failures += !gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength);
 
   // Mux back to UART3 again, and test that UART again passes and GPIO fails.
-  if (!pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio1, PmxArduinoD1ToUartTx3)) failures++;
-  if (!pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxUartReceive3ToAhTmpio0)) failures++;
-  if (!uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes)) failures++;
-  if (gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength)) failures++;
+  failures += !pinmux->output_pin_select(SonataPinmux::OutputPin::ah_tmpio1, PmxArduinoD1ToUartTx3);
+  failures += !pinmux->block_input_select(SonataPinmux::BlockInput::uart_3_rx, PmxUartReceive3ToAhTmpio0);
+  failures += !uart_send_receive_test(prng, uart3, UartTimeoutUsec, UartTestBytes);
+  failures += gpio_write_read_test(gpio, GpioPinOutput, GpioPinInput, GpioWaitUsec, GpioTestLength);
 
   return failures;
 }

--- a/sw/cheri/tests/usbdev_tests.hh
+++ b/sw/cheri/tests/usbdev_tests.hh
@@ -108,10 +108,12 @@ void usbdev_tests(CapRoot root, Log &log) {
   // Execute the specified number of iterations of each test
   for (size_t i = 0; i < USBDEV_TEST_ITERATIONS; i++) {
     log.println("\n\nrunning usbdev_test: {} \\ {}", i, USBDEV_TEST_ITERATIONS - 1);
-    log.println("\x1b[35m(needs User USB connected to a Type-A USB host port)\x1b[0m");
+    set_console_mode(log, CC_PURPLE);
+    log.println("(needs User USB connected to a Type-A USB host port)");
+    set_console_mode(log, CC_RESET);
 
     int failures = 0;
-    log.print("Running USBDEV configure test... ");
+    log.print("  Running USBDEV configure test... ");
     failures = usbdev_configure_test(usbdev);
     write_test_result(log, failures);
 


### PR DESCRIPTION
Addresses some comments from the Pinmux tests PR (#227) after it was merged. This adds in some missing SPI (re)-initialisation logic and does some minor refactoring to make the code cleaner in places. It also makes a minor change formatting the output of the USB test to make it more consistent.

See the comments and discussion on that PR for the reasons for these changes (or omissions of changes). The migration to using the new GPIO driver in `cheriot-rtos` should be done in a separate PR as that is a wider change to the codebase which should be isolated.

The first commit (4d3d1712e7a9e3d93bda4e10c4dfc7d4ce8ebb69) is addressing comments from @HU90m, the second (b6be3bb53b509747728d146d3c6995eec661f1b7) is addressing comments from @engdoreis.