### PR TITLE
Recover from low Rx input. Reduce test duration by shortening time delays and using higher I2C speed.

### DIFF
--- a/sw/cheri/tests/i2c_tests.hh
+++ b/sw/cheri/tests/i2c_tests.hh
@@ -193,7 +193,7 @@ int i2c_rpi_hat_id_eeprom_test(I2cPtr i2c) {
   // Setup the i2c bus, configuring it in host mode with speed of 100.
   i2c->reset_fifos();
   i2c->host_mode_set();
-  i2c->speed_set(100);
+  i2c->speed_set(1000);
 
   // Send two 0x0000 byte addresses and skip the STOP condition.
   const uint8_t addr[] = {0, 0};


### PR DESCRIPTION
Prevent a low GPIO input to the UART Rx input causing the test to run indefinitely without timeout. A low Rx input keeps the UART RX logic active and prevents it becoming Idle except for infrequent single-cycle assertions of Idle.
Also switch the output driver before redirecting the input for more predictable behaviour.

Use higher I2C speed when reading the RPi HAT ID EEPROM to reduce the test duration substantially.

Reduce the timeout values in the UART and GPIO testing to more practical values for FPGA and reduce the simulation time.