### PR TITLE
Fix "all blocks" manual pinmux check so it works again after Chip Select added to Pinmux

### DIFF
--- a/data/top_config.toml
+++ b/data/top_config.toml
@@ -423,14 +423,15 @@ block_ios = [{block = "pwm", instance = 0, io = "ios", io_index = 0}]
 [[pins]]
 name = "pmod0_0"
 block_ios = [
-  {block = "gpio", instance = 2, io = "ios", io_index = 0},  # can be used as SPI CS
+  {block = "gpio", instance = 2, io = "ios", io_index = 0},
+  {block = "spi", instance = 2, io = "cs", io_index = 0},
  ]
 
 [[pins]]
 name = "pmod0_1"
 block_ios = [
   {block = "gpio", instance = 2, io = "ios", io_index = 1},
-  {block = "spi", instance = 3, io = "tx"},
+  {block = "spi", instance = 2, io = "tx"},
   {block = "uart", instance = 2, io = "tx"},
 ]
 
@@ -439,7 +440,7 @@ name = "pmod0_2"
 block_ios = [
   {block = "gpio", instance = 2, io = "ios", io_index = 2},
   {block = "i2c", instance = 0, io = "scl"},
-  {block = "spi", instance = 3, io = "rx"},
+  {block = "spi", instance = 2, io = "rx"},
   {block = "uart", instance = 2, io = "rx"},
 ]
 
@@ -448,7 +449,7 @@ name = "pmod0_3"
 block_ios = [
   {block = "gpio", instance = 2, io = "ios", io_index = 3},
   {block = "i2c", instance = 0, io = "sda"},
-  {block = "spi", instance = 3, io = "sck"},
+  {block = "spi", instance = 2, io = "sck"},
 ]
 
 [[pins]]
@@ -470,14 +471,15 @@ block_ios = [{block = "gpio", instance = 2, io = "ios", io_index = 7}]
 [[pins]]
 name = "pmod1_0"
 block_ios = [
-  {block = "gpio", instance = 2, io = "ios", io_index = 8},  # can be used as SPI CS
+  {block = "gpio", instance = 2, io = "ios", io_index = 8},
+  {block = "spi", instance = 3, io = "cs", io_index = 0},
 ]
 
 [[pins]]
 name = "pmod1_1"
 block_ios = [
   {block = "gpio", instance = 2, io = "ios", io_index = 9},
-  {block = "spi", instance = 4, io = "tx"},
+  {block = "spi", instance = 3, io = "tx"},
   {block = "uart", instance = 3, io = "tx"},
 ]
 
@@ -486,7 +488,7 @@ name = "pmod1_2"
 block_ios = [
   {block = "gpio", instance = 2, io = "ios", io_index = 10},
   {block = "i2c", instance = 1, io = "scl"},
-  {block = "spi", instance = 4, io = "rx"},
+  {block = "spi", instance = 3, io = "rx"},
   {block = "uart", instance = 3, io = "rx"},
 ]
 
@@ -495,7 +497,7 @@ name = "pmod1_3"
 block_ios = [
   {block = "gpio", instance = 2, io = "ios", io_index = 11},
   {block = "i2c", instance = 1, io = "sda"},
-  {block = "spi", instance = 4, io = "sck"},
+  {block = "spi", instance = 3, io = "sck"},
 ]
 
 [[pins]]

--- a/doc/ip/pinmux/README.md
+++ b/doc/ip/pinmux/README.md
@@ -77,18 +77,18 @@ The default value for all of these selectors is `'b10`.
 | 0x03e | `mb6` | 0, `i2c[1].scl` |
 | 0x03f | `mb7` | 0, `uart[3].tx` |
 | 0x040 | `mb10` | 0, `pwm[0].ios[0]` |
-| 0x041 | `pmod0_0` | 0, `gpio[2].ios[0]` |
-| 0x042 | `pmod0_1` | 0, `gpio[2].ios[1]`, `spi[3].tx`, `uart[2].tx` |
+| 0x041 | `pmod0_0` | 0, `gpio[2].ios[0]`, `spi[2].cs[0]` |
+| 0x042 | `pmod0_1` | 0, `gpio[2].ios[1]`, `spi[2].tx`, `uart[2].tx` |
 | 0x043 | `pmod0_2` | 0, `gpio[2].ios[2]`, `i2c[0].scl` |
-| 0x044 | `pmod0_3` | 0, `gpio[2].ios[3]`, `i2c[0].sda`, `spi[3].sck` |
+| 0x044 | `pmod0_3` | 0, `gpio[2].ios[3]`, `i2c[0].sda`, `spi[2].sck` |
 | 0x045 | `pmod0_4` | 0, `gpio[2].ios[4]` |
 | 0x046 | `pmod0_5` | 0, `gpio[2].ios[5]` |
 | 0x047 | `pmod0_6` | 0, `gpio[2].ios[6]` |
 | 0x048 | `pmod0_7` | 0, `gpio[2].ios[7]` |
-| 0x049 | `pmod1_0` | 0, `gpio[2].ios[8]` |
-| 0x04a | `pmod1_1` | 0, `gpio[2].ios[9]`, `spi[4].tx`, `uart[3].tx` |
+| 0x049 | `pmod1_0` | 0, `gpio[2].ios[8]`, `spi[3].cs[0]` |
+| 0x04a | `pmod1_1` | 0, `gpio[2].ios[9]`, `spi[3].tx`, `uart[3].tx` |
 | 0x04b | `pmod1_2` | 0, `gpio[2].ios[10]`, `i2c[1].scl` |
-| 0x04c | `pmod1_3` | 0, `gpio[2].ios[11]`, `i2c[1].sda`, `spi[4].sck` |
+| 0x04c | `pmod1_3` | 0, `gpio[2].ios[11]`, `i2c[1].sda`, `spi[3].sck` |
 | 0x04d | `pmod1_4` | 0, `gpio[2].ios[12]` |
 | 0x04e | `pmod1_5` | 0, `gpio[2].ios[13]` |
 | 0x04f | `pmod1_6` | 0, `gpio[2].ios[14]` |
@@ -108,9 +108,9 @@ Besides the output pin selectors, there are also selectors for which pin should 
 | 0x804 | `uart[4].rx` | 1, `rs232_rx` |
 | 0x805 | `spi[0].rx` | 0, `appspi_d1` |
 | 0x806 | `spi[1].rx` | 0, 0 |
-| 0x807 | `spi[2].rx` | 0, `ethmac_cipo` |
-| 0x808 | `spi[3].rx` | 0, `rph_g9_cipo`, `ah_tmpio12`, `pmod0_2`, `microsd_dat0` |
-| 0x809 | `spi[4].rx` | 0, `rph_g19_cipo`, `mb3`, `pmod1_2` |
+| 0x807 | `spi[2].rx` | 0, `ethmac_cipo`, `pmod0_2` |
+| 0x808 | `spi[3].rx` | 0, `rph_g9_cipo`, `ah_tmpio12`, `pmod1_2`, `microsd_dat0` |
+| 0x809 | `spi[4].rx` | 0, `rph_g19_cipo`, `mb3` |
 | 0x80a | `gpio[0].ios[0]` | 0, `rph_g0` |
 | 0x80b | `gpio[1].ios[0]` | 0, `ah_tmpio0` |
 | 0x80c | `gpio[2].ios[0]` | 0, `pmod0_0` |

--- a/rtl/system/pinmux.sv
+++ b/rtl/system/pinmux.sv
@@ -3260,7 +3260,7 @@ module pinmux
     .out_o(out_to_pins_en_o[OUT_PIN_MB10])
   );
 
-  logic [1:0] pmod0_0_sel;
+  logic [2:0] pmod0_0_sel;
   logic pmod0_0_sel_addressed;
 
   // Register addresses of 0x000 to 0x7ff are pin selectors, which are packed with 4 per 32-bit word.
@@ -3272,23 +3272,24 @@ module pinmux
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       // Select second input by default so that pins are connected to the first block that is specified in the configuration.
-      pmod0_0_sel <= 2'b10;
+      pmod0_0_sel <= 3'b10;
     end else begin
       if (reg_we & pmod0_0_sel_addressed) begin
-        pmod0_0_sel <= reg_wdata[8+:2];
+        pmod0_0_sel <= reg_wdata[8+:3];
       end
     end
   end
 
   prim_onehot_mux #(
     .Width(1),
-    .Inputs(2)
+    .Inputs(3)
   ) pmod0_0_mux (
     .clk_i,
     .rst_ni,
     .in_i({
       1'b0, // This is set to Z later when output enable is low.
-      gpio_ios_i[2][0]
+      gpio_ios_i[2][0],
+      spi_cs_i[2][0]
     }),
     .sel_i(pmod0_0_sel),
     .out_o(inout_to_pins_o[INOUT_PIN_PMOD0_0])
@@ -3296,13 +3297,14 @@ module pinmux
 
   prim_onehot_mux #(
     .Width(1),
-    .Inputs(2)
+    .Inputs(3)
   ) pmod0_0_enable_mux (
     .clk_i,
     .rst_ni,
     .in_i({
       1'b0,
-      gpio_ios_en_i[2][0]
+      gpio_ios_en_i[2][0],
+      spi_cs_en_i[2][0]
     }),
     .sel_i(pmod0_0_sel),
     .out_o(inout_to_pins_en_o[INOUT_PIN_PMOD0_0])
@@ -3337,7 +3339,7 @@ module pinmux
     .in_i({
       1'b0, // This is set to Z later when output enable is low.
       gpio_ios_i[2][1],
-      spi_tx_i[3],
+      spi_tx_i[2],
       uart_tx_i[2]
     }),
     .sel_i(pmod0_1_sel),
@@ -3353,7 +3355,7 @@ module pinmux
     .in_i({
       1'b0,
       gpio_ios_en_i[2][1],
-      spi_tx_en_i[3],
+      spi_tx_en_i[2],
       uart_tx_en_i[2]
     }),
     .sel_i(pmod0_1_sel),
@@ -3440,7 +3442,7 @@ module pinmux
       1'b0, // This is set to Z later when output enable is low.
       gpio_ios_i[2][3],
       i2c_sda_i[0],
-      spi_sck_i[3]
+      spi_sck_i[2]
     }),
     .sel_i(pmod0_3_sel),
     .out_o(inout_to_pins_o[INOUT_PIN_PMOD0_3])
@@ -3456,7 +3458,7 @@ module pinmux
       1'b0,
       gpio_ios_en_i[2][3],
       i2c_sda_en_i[0],
-      spi_sck_en_i[3]
+      spi_sck_en_i[2]
     }),
     .sel_i(pmod0_3_sel),
     .out_o(inout_to_pins_en_o[INOUT_PIN_PMOD0_3])
@@ -3654,7 +3656,7 @@ module pinmux
     .out_o(inout_to_pins_en_o[INOUT_PIN_PMOD0_7])
   );
 
-  logic [1:0] pmod1_0_sel;
+  logic [2:0] pmod1_0_sel;
   logic pmod1_0_sel_addressed;
 
   // Register addresses of 0x000 to 0x7ff are pin selectors, which are packed with 4 per 32-bit word.
@@ -3666,23 +3668,24 @@ module pinmux
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       // Select second input by default so that pins are connected to the first block that is specified in the configuration.
-      pmod1_0_sel <= 2'b10;
+      pmod1_0_sel <= 3'b10;
     end else begin
       if (reg_we & pmod1_0_sel_addressed) begin
-        pmod1_0_sel <= reg_wdata[8+:2];
+        pmod1_0_sel <= reg_wdata[8+:3];
       end
     end
   end
 
   prim_onehot_mux #(
     .Width(1),
-    .Inputs(2)
+    .Inputs(3)
   ) pmod1_0_mux (
     .clk_i,
     .rst_ni,
     .in_i({
       1'b0, // This is set to Z later when output enable is low.
-      gpio_ios_i[2][8]
+      gpio_ios_i[2][8],
+      spi_cs_i[3][0]
     }),
     .sel_i(pmod1_0_sel),
     .out_o(inout_to_pins_o[INOUT_PIN_PMOD1_0])
@@ -3690,13 +3693,14 @@ module pinmux
 
   prim_onehot_mux #(
     .Width(1),
-    .Inputs(2)
+    .Inputs(3)
   ) pmod1_0_enable_mux (
     .clk_i,
     .rst_ni,
     .in_i({
       1'b0,
-      gpio_ios_en_i[2][8]
+      gpio_ios_en_i[2][8],
+      spi_cs_en_i[3][0]
     }),
     .sel_i(pmod1_0_sel),
     .out_o(inout_to_pins_en_o[INOUT_PIN_PMOD1_0])
@@ -3731,7 +3735,7 @@ module pinmux
     .in_i({
       1'b0, // This is set to Z later when output enable is low.
       gpio_ios_i[2][9],
-      spi_tx_i[4],
+      spi_tx_i[3],
       uart_tx_i[3]
     }),
     .sel_i(pmod1_1_sel),
@@ -3747,7 +3751,7 @@ module pinmux
     .in_i({
       1'b0,
       gpio_ios_en_i[2][9],
-      spi_tx_en_i[4],
+      spi_tx_en_i[3],
       uart_tx_en_i[3]
     }),
     .sel_i(pmod1_1_sel),
@@ -3834,7 +3838,7 @@ module pinmux
       1'b0, // This is set to Z later when output enable is low.
       gpio_ios_i[2][11],
       i2c_sda_i[1],
-      spi_sck_i[4]
+      spi_sck_i[3]
     }),
     .sel_i(pmod1_3_sel),
     .out_o(inout_to_pins_o[INOUT_PIN_PMOD1_3])
@@ -3850,7 +3854,7 @@ module pinmux
       1'b0,
       gpio_ios_en_i[2][11],
       i2c_sda_en_i[1],
-      spi_sck_en_i[4]
+      spi_sck_en_i[3]
     }),
     .sel_i(pmod1_3_sel),
     .out_o(inout_to_pins_en_o[INOUT_PIN_PMOD1_3])
@@ -4435,7 +4439,7 @@ module pinmux
     .out_o(spi_rx_o[1])
   );
 
-  logic [1:0] spi_rx_2_sel;
+  logic [2:0] spi_rx_2_sel;
   logic spi_rx_2_sel_addressed;
 
   // Register addresses of 0x800 to 0xfff are block IO selectors, which are packed with 4 per 32-bit word.
@@ -4447,23 +4451,24 @@ module pinmux
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       // Select second input by default so that pins are connected to the first block that is specified in the configuration.
-      spi_rx_2_sel <= 2'b10;
+      spi_rx_2_sel <= 3'b10;
     end else begin
       if (reg_we & spi_rx_2_sel_addressed) begin
-        spi_rx_2_sel <= reg_wdata[24+:2];
+        spi_rx_2_sel <= reg_wdata[24+:3];
       end
     end
   end
 
   prim_onehot_mux #(
     .Width(1),
-    .Inputs(2)
+    .Inputs(3)
   ) spi_rx_2_mux (
     .clk_i,
     .rst_ni,
     .in_i({
       1'b0,
-      in_from_pins_i[IN_PIN_ETHMAC_CIPO]
+      in_from_pins_i[IN_PIN_ETHMAC_CIPO],
+      inout_from_pins_i[INOUT_PIN_PMOD0_2]
     }),
     .sel_i(spi_rx_2_sel),
     .out_o(spi_rx_o[2])
@@ -4499,14 +4504,14 @@ module pinmux
       1'b0,
       inout_from_pins_i[INOUT_PIN_RPH_G9_CIPO],
       inout_from_pins_i[INOUT_PIN_AH_TMPIO12],
-      inout_from_pins_i[INOUT_PIN_PMOD0_2],
+      inout_from_pins_i[INOUT_PIN_PMOD1_2],
       in_from_pins_i[IN_PIN_MICROSD_DAT0]
     }),
     .sel_i(spi_rx_3_sel),
     .out_o(spi_rx_o[3])
   );
 
-  logic [3:0] spi_rx_4_sel;
+  logic [2:0] spi_rx_4_sel;
   logic spi_rx_4_sel_addressed;
 
   // Register addresses of 0x800 to 0xfff are block IO selectors, which are packed with 4 per 32-bit word.
@@ -4518,25 +4523,24 @@ module pinmux
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       // Select second input by default so that pins are connected to the first block that is specified in the configuration.
-      spi_rx_4_sel <= 4'b10;
+      spi_rx_4_sel <= 3'b10;
     end else begin
       if (reg_we & spi_rx_4_sel_addressed) begin
-        spi_rx_4_sel <= reg_wdata[8+:4];
+        spi_rx_4_sel <= reg_wdata[8+:3];
       end
     end
   end
 
   prim_onehot_mux #(
     .Width(1),
-    .Inputs(4)
+    .Inputs(3)
   ) spi_rx_4_mux (
     .clk_i,
     .rst_ni,
     .in_i({
       1'b0,
       inout_from_pins_i[INOUT_PIN_RPH_G19_CIPO],
-      in_from_pins_i[IN_PIN_MB3],
-      inout_from_pins_i[INOUT_PIN_PMOD1_2]
+      in_from_pins_i[IN_PIN_MB3]
     }),
     .sel_i(spi_rx_4_sel),
     .out_o(spi_rx_o[4])

--- a/sw/cheri/checks/pinmux_all_blocks_check.cc
+++ b/sw/cheri/checks/pinmux_all_blocks_check.cc
@@ -44,8 +44,8 @@ using namespace CHERI;
 
   // Create capabilities for SPI3&4, I2C0&1, GPIO and Pinmux for use in Pinmux testing
   SpiPtr spis[2] = {
+      spi_ptr(rwRoot, 2),
       spi_ptr(rwRoot, 3),
-      spi_ptr(rwRoot, 4),
   };
   I2cPtr i2cs[2] = {i2c_ptr(root, 0), i2c_ptr(root, 1)};
 
@@ -95,15 +95,15 @@ using namespace CHERI;
   pmod_test_i2c_off_pins[1] = {SonataPinmux::OutputPin::pmod0_3, 0};
 
   OutputPinAssignment pmod_test_spi_on_pins[3];
-  pmod_test_spi_on_pins[0]                       = {SonataPinmux::OutputPin::pmod0_0, 1};  // Mux to GPIO for CS
+  pmod_test_spi_on_pins[0]                       = {SonataPinmux::OutputPin::pmod0_0, 2};  // Mux to SPI CS
   pmod_test_spi_on_pins[1]                       = {SonataPinmux::OutputPin::pmod0_1, 2};  // Mux to SPI COPI
   pmod_test_spi_on_pins[2]                       = {SonataPinmux::OutputPin::pmod0_3, 3};  // Mux to SPI SCK
-  BlockInputAssignment pmod_test_spi_on_inputs[] = {{SonataPinmux::BlockInput::spi_3_rx, 3}};
+  BlockInputAssignment pmod_test_spi_on_inputs[] = {{SonataPinmux::BlockInput::spi_2_rx, 2}};
   OutputPinAssignment pmod_test_spi_off_pins[3];
   pmod_test_spi_off_pins[0]                       = {SonataPinmux::OutputPin::pmod0_0, 0};
   pmod_test_spi_off_pins[1]                       = {SonataPinmux::OutputPin::pmod0_1, 0};
   pmod_test_spi_off_pins[2]                       = {SonataPinmux::OutputPin::pmod0_3, 0};
-  BlockInputAssignment pmod_test_spi_off_inputs[] = {{SonataPinmux::BlockInput::spi_3_rx, 0}};
+  BlockInputAssignment pmod_test_spi_off_inputs[] = {{SonataPinmux::BlockInput::spi_2_rx, 0}};
 
   // The pinmux testplan to execute. This testplan runs through testing GPIO, UART, I2C and SPI
   // all on the same PMOD pins, with users manually changing out the connected devices between
@@ -208,11 +208,8 @@ using namespace CHERI;
           .num_output_pins  = ARRAYSIZE(pmod_test_spi_on_pins),
           .block_inputs     = pmod_test_spi_on_inputs,
           .num_block_inputs = ARRAYSIZE(pmod_test_spi_on_inputs),
-          .spi_data =
-              {
-                  SpiTest::SpiNum::Spi3, {GpioInstance::Pmod, 0},  // PMOD0_1 is used as the CS signal
-              },
-          .expected_result = true,
+          .spi_data         = {SpiTest::SpiNum::Spi2},
+          .expected_result  = true,
       },
       {
           .type             = TestType::SpiPmodSF3ReadId,
@@ -222,11 +219,8 @@ using namespace CHERI;
           .num_output_pins  = ARRAYSIZE(pmod_test_spi_off_pins),
           .block_inputs     = pmod_test_spi_off_inputs,
           .num_block_inputs = ARRAYSIZE(pmod_test_spi_off_inputs),
-          .spi_data =
-              {
-                  SpiTest::SpiNum::Spi3, {GpioInstance::Pmod, 0},  // PMOD0_1 is used as the CS signal
-              },
-          .expected_result = false,
+          .spi_data         = {SpiTest::SpiNum::Spi2},
+          .expected_result  = false,
       },
   };
 

--- a/sw/cheri/checks/pinmux_checker.cc
+++ b/sw/cheri/checks/pinmux_checker.cc
@@ -111,7 +111,7 @@ static bool spi_n25q256a_read_jedec_id(SpiPtr spi) {
  * Execute a UART send/receive test using the UART specified in the test.
  */
 static bool execute_uart_test(const Test &test, ds::xoroshiro::P32R8 &prng, UartPtr uarts[4]) {
-  UartPtr tested_uart = uarts[static_cast<uint8_t>(test.uart_data.uart) - 1];
+  UartPtr tested_uart = uarts[static_cast<uint8_t>(test.uart_data.uart)];
   bool result         = uart_send_receive_test(prng, tested_uart, test.uart_data.timeout, test.uart_data.test_length);
   return result == test.expected_result;
 }
@@ -150,7 +150,7 @@ static bool execute_i2c_pmod_colour_test(const Test &test, I2cPtr i2cs[2], Log &
  * the test.
  */
 static bool execute_spi_test(const Test &test, SpiPtr spis[2]) {
-  SpiPtr tested_spi = spis[static_cast<uint8_t>(test.spi_data.spi) - 2];
+  SpiPtr tested_spi = spis[static_cast<uint8_t>(test.spi_data.spi)];
   bool result       = spi_n25q256a_read_jedec_id(tested_spi);
   return result == test.expected_result;
 }

--- a/sw/cheri/checks/pinmux_checker.cc
+++ b/sw/cheri/checks/pinmux_checker.cc
@@ -98,7 +98,7 @@ static bool spi_n25q256a_read_jedec_id(SpiPtr spi) {
   spi->cs = (spi->cs | 1u);  // Set ¬CS Low
 
   // Check that the retrieved ID matches our expected value
-  for (size_t index = 0; index < 3; index++) {
+  for (size_t index = 0; index < sizeof(jedec_id); index++) {
     if (jedec_id[index] != ExpectedJedecId[index]) {
       return false;
     }
@@ -112,7 +112,7 @@ static bool spi_n25q256a_read_jedec_id(SpiPtr spi) {
  */
 static bool execute_uart_test(const Test &test, ds::xoroshiro::P32R8 &prng, UartPtr uarts[4]) {
   UartPtr tested_uart = uarts[static_cast<uint8_t>(test.uart_data.uart) - 1];
-  bool result         = uart_send_receive_test(prng, tested_uart, 10, 100);
+  bool result         = uart_send_receive_test(prng, tested_uart, test.uart_data.timeout, test.uart_data.test_length);
   return result == test.expected_result;
 }
 

--- a/sw/cheri/checks/pinmux_checker.hh
+++ b/sw/cheri/checks/pinmux_checker.hh
@@ -41,10 +41,11 @@ enum class TestType {
 struct UartTest {
   enum class UartNum : uint8_t {
     // Uart0 is used as a console and cannot be tested
-    Uart1 = 1,
-    Uart2 = 2,
-    Uart3 = 3,
-    Uart4 = 4,
+    Uart1,
+    Uart2,
+    Uart3,
+    Uart4,
+    NumUarts,
   } uart;
   uint32_t timeout;
   uint32_t test_length;
@@ -61,8 +62,9 @@ struct GpioTest {
 // The test-specific data required to carry out an I2C BH1745 Read ID test
 struct I2cTest {
   enum class I2cNum : uint8_t {
-    I2c0 = 0,
-    I2c1 = 1,
+    I2c0,
+    I2c1,
+    NumI2c,
   } i2c;
 };
 
@@ -70,8 +72,9 @@ struct I2cTest {
 struct SpiTest {
   enum class SpiNum : uint8_t {
     // Spi0-1 are used for the Flash and LCD and so cannot be tested.
-    Spi2 = 2,
-    Spi3 = 3,
+    Spi2,
+    Spi3,
+    NumSpi,
   } spi;
 };
 

--- a/sw/cheri/checks/pinmux_checker.hh
+++ b/sw/cheri/checks/pinmux_checker.hh
@@ -69,11 +69,10 @@ struct I2cTest {
 // The test-specific data required to carry out a SPI Pmod SF3 Read ID test
 struct SpiTest {
   enum class SpiNum : uint8_t {
-    // Spi0-2 are the Flash, LCD and Ethernet respectively and cannot be tested.
+    // Spi0-1 are used for the Flash and LCD and so cannot be tested.
+    Spi2 = 2,
     Spi3 = 3,
-    Spi4 = 4,
   } spi;
-  GpioPin cs_pin;
 };
 
 // An output pin assignment to be made via Pinmux for a test

--- a/sw/cheri/common/platform-pinmux.hh
+++ b/sw/cheri/common/platform-pinmux.hh
@@ -297,7 +297,9 @@ class SonataPinmux : private utils::NoCopyNoMove {
       case OutputPin::ah_tmpio10:
       case OutputPin::ah_tmpio11:
       case OutputPin::ah_tmpio13:
+      case OutputPin::pmod0_0:
       case OutputPin::pmod0_2:
+      case OutputPin::pmod1_0:
       case OutputPin::pmod1_2:
         return 3;
       default:
@@ -322,9 +324,10 @@ class SonataPinmux : private utils::NoCopyNoMove {
       case BlockInput::spi_3_rx:
         return 5;
       case BlockInput::uart_3_rx:
-      case BlockInput::spi_4_rx:
         return 4;
       case BlockInput::uart_2_rx:
+      case BlockInput::spi_2_rx:
+      case BlockInput::spi_4_rx:
         return 3;
       default:
         return 2;


### PR DESCRIPTION
This PR fixes the "all blocks" manual pinmux check (and the pinmux checker in general) so that the latest `main` which includes changes from #262 will now work again. See the commit messages for more details.

This PR primarily does 3 things:
1. Updates the Pinmux config to add the SPI Chip Select to PMOD, where it was previously missing. Whilst at it, I also updated PMOD0 to use SPI2 instead of SPI3, and PMOD1 to use SPI3 instead of SPI4, because it appears that the eventual pinmux mapping (see [here](https://github.com/lowRISC/sonata-system/blob/8df6c195198b7b0121173351391f841b0896a176/doc/ip/pinmux/pin_mappings.svg)) intends to use this mapping. By making this smaller change now in this PR, it reduces the amount of work we have to do later, as the "all blocks" test should stay passing and not break with that PR.
2. It then updates the pinmux checker and the "all blocks" check to use the above features. That is, it modifies the SPI test in the pinmux checker to now use the SPI's CS rather than just a GPIO pin, and it changes the available SPI to be 2-3 instead of 3-4 as before. It updates the pinmux mappings and SPI instance being used in the "all blocks" testplan to match the new values in `pinmux.md` after the config change.
3. Finally, it fixes a couple of minor issues I found while looking at the code. One is just a small good practice (use `sizeof(jedec_id)` instead of `3`), and the other is changing the UART test so that it now actually uses the `timeout` and `test_length` values provided in the test, rather than hard-coded literals as I had apparently accidentally done previously.

This has been tested with the existing pinmux tests (which will also run in CI), as well as the manual "all blocks" check itself, and the small manual pinmux check over UART0. All pass as expected. 