### PR TITLE
Improve Pinmux testing to account for SPI Chip Select

### DIFF
--- a/sw/cheri/tests/spi_tests.hh
+++ b/sw/cheri/tests/spi_tests.hh
@@ -192,7 +192,7 @@ int spi_read_flash_jedec_id_test(Capability<volatile SonataSpi> spi, SpiFlash sp
   spi_flash.read_jedec_id(jedec_id);
 
   // Check that the retrieved ID matches our expected value
-  for (size_t index = 0; index < 3; index++) {
+  for (size_t index = 0; index < sizeof(jedec_id); index++) {
     if (jedec_id[index] != ExpectedSpiFlashJedecId[index]) {
       failures++;
     }


### PR DESCRIPTION
See commit messages for more details.

Alongside a couple of code improvements, this PR primarily focuses on the following:
 - Make the existing SPI Pinmux test also mux the Flash's CS pin.
 - Make the SPI Pinmux test more resilient by resetting the flash after muxing any SPI pins, to recover from erroneous states caused by muxing pins.
 - Extend the SPI Pinmux test to specifically check whether muxing of the CS is working. That is, it only disables the CS via pinmux and checks that the test fails, and then re-enables it and checks that it passes again. This is to give confidence that the pinmux surrounding chip selects specifically is working, as this is an area that has undergone a lot of changes recently in the RTL.

This has been tested to pass on FPGA locally; as it only touches the tests nothing should change with regards to other pinmux checks.