### PR TITLE
LCD DPI model and lcd_check updates

### DIFF
--- a/dv/dpi/spidpi/spi_lcd.hh
+++ b/dv/dpi/spidpi/spi_lcd.hh
@@ -32,8 +32,8 @@ protected:
 private:
   // These are the physical properties of the LCD, not the screen properties from the perspective
   // of the driver software.
-  static constexpr unsigned kWidth  = 160u;
-  static constexpr unsigned kHeight = 128u;
+  static constexpr unsigned kWidth  = 128u;
+  static constexpr unsigned kHeight = 160u;
   typedef uint16_t pixel_t;
 
   // Write the LCD image out to the given file if enough time has elapsed since the most

--- a/sw/cheri/checks/lcd_check.cc
+++ b/sw/cheri/checks/lcd_check.cc
@@ -8,7 +8,7 @@
 
 #include "../../common/defs.h"
 
-#include <platform-gpio.hh>
+#include <platform-pwm.hh>
 #include <platform-spi.hh>
 #include <platform-uart.hh>
 
@@ -20,19 +20,29 @@ using namespace CHERI;
 #include "../../../vendor/display_drivers/st7735/lcd_st7735_init.h"
 #include "lowrisc_logo_native.h"
 
+typedef SonataPulseWidthModulation SonataPwm;
+
 // When running in simulation, eliminate the delays?
 #define SIMULATION 0
 
-const int LcdRstPin = 1, LcdDcPin = 2, LcdBlPin = 3;
+const int LcdRstPin = 2, LcdDcPin = 1;
+
+// Use landscape orientation rather than portrait?
+#define LANDSCAPE 0
 
 // LCD properties.
+#if LANDSCAPE
+const uint32_t width  = 160u;
+const uint32_t height = 128u;
+#else
 const uint32_t width  = 128u;
 const uint32_t height = 160u;
+#endif
 // Logo properties.
 const uint32_t img_width  = 105u;
 const uint32_t img_height = 80u;
 
-#define set_output_bit(a, b, c) gpio->output = (c) ? (gpio->output | (1 << (b))) : (gpio->output & ~(1 << (b)))
+#define set_output_bit(a, b, c) (a)->cs = (c) ? ((a)->cs | (1 << (b))) : ((a)->cs & ~(1 << (b)))
 
 // Commonly-used LCD command codes.
 static const uint8_t madctl = ST7735_MADCTL;
@@ -47,15 +57,13 @@ static inline void delay(int delay_ms) {
 #endif
 }
 
-static inline void set_cs_dc(Capability<volatile SonataSpi> &spi, Capability<volatile SonataGPIO> &gpio, bool cs,
-                             bool d) {
-  set_output_bit(0, LcdDcPin, d);
+static inline void set_cs_dc(Capability<volatile SonataSpi> &spi, bool cs, bool d) {
+  set_output_bit(spi, LcdDcPin, d);
   spi->cs = cs ? (spi->cs | 1u) : (spi->cs & ~1u);
 }
 
-static void write_command(Capability<volatile SonataSpi> &spi, Capability<volatile SonataGPIO> &gpio,
-                          const uint8_t *cmd, size_t len) {
-  set_cs_dc(spi, gpio, false, false);
+static void write_command(Capability<volatile SonataSpi> &spi, const uint8_t *cmd, size_t len) {
+  set_cs_dc(spi, false, false);
   spi->blocking_write(cmd, len);
   spi->wait_idle();
 }
@@ -71,56 +79,54 @@ static void write_buffer(Capability<volatile SonataSpi> &spi, const uint8_t *dat
   }
 }
 
-static void write_data(Capability<volatile SonataSpi> &spi, Capability<volatile SonataGPIO> &gpio, const uint8_t *data,
-                       size_t len) {
-  set_cs_dc(spi, gpio, false, true);
+static void write_data(Capability<volatile SonataSpi> &spi, const uint8_t *data, size_t len) {
+  set_cs_dc(spi, false, true);
   write_buffer(spi, data, len);
   spi->wait_idle();
-  set_cs_dc(spi, gpio, true, true);
+  set_cs_dc(spi, true, true);
 }
 
-static void set_address(Capability<volatile SonataSpi> &spi, Capability<volatile SonataGPIO> &gpio, uint16_t x0,
-                        uint16_t y0, uint16_t x1, uint16_t y1) {
+static void set_address(Capability<volatile SonataSpi> &spi, uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
   uint8_t coord[4];
 
   coord[0] = (uint8_t)(x0 >> 8);
   coord[1] = (uint8_t)x0;
   coord[2] = (uint8_t)(x1 >> 8);
   coord[3] = (uint8_t)x1;
-  write_command(spi, gpio, &caset, 1u);
-  write_data(spi, gpio, coord, 4u);
+  write_command(spi, &caset, 1u);
+  write_data(spi, coord, 4u);
 
   coord[0] = (uint8_t)(y0 >> 8);
   coord[1] = (uint8_t)y0;
   coord[2] = (uint8_t)(y1 >> 8);
   coord[3] = (uint8_t)y1;
-  write_command(spi, gpio, &raset, 1u);
-  write_data(spi, gpio, coord, 4u);
+  write_command(spi, &raset, 1u);
+  write_data(spi, coord, 4u);
 }
 
-static void fill_rect(Capability<volatile SonataSpi> &spi, Capability<volatile SonataGPIO> &gpio, uint16_t x0,
-                      uint16_t y0, uint16_t x1, uint16_t y1, uint32_t pix) {
-  set_address(spi, gpio, x0, y0, x1, y1);
+static void fill_rect(Capability<volatile SonataSpi> &spi, uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1,
+                      uint32_t pix) {
+  set_address(spi, x0, y0, x1, y1);
 
-  write_command(spi, gpio, &ramwr, 1u);
-  set_cs_dc(spi, gpio, false, true);
+  write_command(spi, &ramwr, 1u);
+  set_cs_dc(spi, false, true);
   uint32_t npix = (1 + y1 - y0) * (1 + x1 - x0);
   while (npix-- > 0u) write_buffer(spi, (uint8_t *)&pix, 2u);
   spi->wait_idle();
-  set_cs_dc(spi, gpio, true, true);
+  set_cs_dc(spi, true, true);
 }
 
-static void draw_image(Capability<volatile SonataSpi> &spi, Capability<volatile SonataGPIO> &gpio, uint16_t x0,
-                       uint16_t y0, uint16_t x1, uint16_t y1, const uint8_t *data) {
+static void draw_image(Capability<volatile SonataSpi> &spi, uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1,
+                       const uint8_t *data) {
   uint32_t npix = (1 + y1 - y0) * (1 + x1 - x0);
 
-  set_address(spi, gpio, x0, y0, x1, y1);
-  write_command(spi, gpio, &ramwr, 1u);
-  write_data(spi, gpio, data, npix << 1);
+  set_address(spi, x0, y0, x1, y1);
+  write_command(spi, &ramwr, 1u);
+  write_data(spi, data, npix << 1);
 }
 
 static void run_script(Capability<volatile OpenTitanUart> &uart, Capability<volatile SonataSpi> &spi,
-                       Capability<volatile SonataGPIO> &gpio, const uint8_t *addr) {
+                       const uint8_t *addr) {
   uint8_t numCommands, numArgs;
   uint16_t delay_ms;
 
@@ -129,13 +135,13 @@ static void run_script(Capability<volatile OpenTitanUart> &uart, Capability<vola
   while (numCommands--) {  // For each command...
     const uint8_t cmd = NEXT_BYTE(addr);
 
-    write_command(spi, gpio, &cmd, 1u);
+    write_command(spi, &cmd, 1u);
 
     numArgs  = NEXT_BYTE(addr);  // Number of args to follow
     delay_ms = numArgs & DELAY;  // If hibit set, delay follows args
     numArgs &= ~DELAY;           // Mask out delay bit
 
-    write_data(spi, gpio, addr, numArgs);
+    write_data(spi, addr, numArgs);
 
     addr += numArgs;
     if (delay_ms) {
@@ -158,13 +164,19 @@ static void run_script(Capability<volatile OpenTitanUart> &uart, Capability<vola
   uart.address()                          = UART_ADDRESS;
   uart.bounds()                           = UART_BOUNDS;
 
+  // The LCD is driven by SPI controller 0.
   Capability<volatile SonataSpi> spi = root.cast<volatile SonataSpi>();
-  spi.address()                      = SPI_ADDRESS + SPI_RANGE;
+  spi.address()                      = SPI_ADDRESS;
   spi.bounds()                       = SPI_BOUNDS;
 
-  Capability<volatile SonataGPIO> gpio = root.cast<volatile SonataGPIO>();
-  gpio.address()                       = GPIO_ADDRESS;
-  gpio.bounds()                        = GPIO_BOUNDS;
+  // Create a bounded capability for the final PWM channel since this drives the LCD backlight.
+  Capability<volatile SonataPwm> pwm = root.cast<volatile SonataPwm>();
+  pwm.address()                      = PWM_ADDRESS + (PWM_NUM - 1) * PWM_RANGE;
+  pwm.bounds()                       = PWM_BOUNDS;
+  // TODO: We presently cannot produce an always-on output using the SonataPwm `output_set` function.
+  // pwm->output_set(0, 1, 2);
+  pwm->outputs[0].dutyCycle = 2u;
+  pwm->outputs[0].period    = 1u;
 
   uart->init(BAUD_RATE);
   write_str(uart, "LCD check\r\n");
@@ -175,25 +187,28 @@ static void run_script(Capability<volatile OpenTitanUart> &uart, Capability<vola
   spi->init(false, false, true, SpiSpeed);
 
   // Set the initial state of the LCD control pins.
-  set_output_bit(GPIO_OUT, LcdDcPin, 0x0);
-  set_output_bit(GPIO_OUT, LcdBlPin, 0x1);
+  set_output_bit(spi, LcdDcPin, 0x0);
 
   // Reset LCD.
-  set_output_bit(GPIO_OUT, LcdRstPin, 0x0);
+  set_output_bit(spi, LcdRstPin, 0x0);
   delay(150);
-  set_output_bit(GPIO_OUT, LcdRstPin, 0x1);
+  set_output_bit(spi, LcdRstPin, 0x1);
 
   // Send display initialisation commands.
-  run_script(uart, spi, gpio, init_script_b);
-  run_script(uart, spi, gpio, init_script_r);
-  run_script(uart, spi, gpio, init_script_r3);
+  run_script(uart, spi, init_script_b);
+  run_script(uart, spi, init_script_r);
+  run_script(uart, spi, init_script_r3);
 
+#if LANDSCAPE
   uint8_t data = ST77_MADCTL_MX | ST77_MADCTL_MV | ST77_MADCTL_RGB;
-  write_command(spi, gpio, &madctl, 1u);
-  write_data(spi, gpio, &data, 1u);
+#else
+  uint8_t data = ST77_MADCTL_MX | ST77_MADCTL_MY | ST77_MADCTL_RGB;
+#endif
+  write_command(spi, &madctl, 1u);
+  write_data(spi, &data, 1u);
 
   const uint32_t back_pix = 0x1f00u;
-  fill_rect(spi, gpio, 0u, 0u, width - 1u, height - 1u, back_pix);
+  fill_rect(spi, 0u, 0u, width - 1u, height - 1u, back_pix);
 
   int32_t logo_x = (width - img_width) >> 1;
   int32_t logo_y = (height - img_height) >> 1;
@@ -204,8 +219,9 @@ static void run_script(Capability<volatile OpenTitanUart> &uart, Capability<vola
   while (true) {
     uint16_t logo_y1 = logo_y + img_height - 1u;
     uint16_t logo_x1 = logo_x + img_width - 1u;
+
     // Render the logo.
-    draw_image(spi, gpio, logo_x, logo_y, logo_x1, logo_y1, (uint8_t *)lowrisc_logo_native);
+    draw_image(spi, logo_x, logo_y, logo_x1, logo_y1, (uint8_t *)lowrisc_logo_native);
 
     // Remove trailing edge(s).
     if (logo_xd) {
@@ -216,7 +232,7 @@ static void run_script(Capability<volatile OpenTitanUart> &uart, Capability<vola
       uint16_t y0 = logo_y - ((logo_yd > 0) ? logo_yd : 0);
       uint16_t y1 = logo_y1 - ((logo_yd < 0) ? logo_yd : 0);
       // Restore the column to the background colour.
-      fill_rect(spi, gpio, x0, y0, x1, y1, back_pix);
+      fill_rect(spi, x0, y0, x1, y1, back_pix);
     }
     if (logo_yd) {
       // Remove the row above or below the image.
@@ -226,7 +242,7 @@ static void run_script(Capability<volatile OpenTitanUart> &uart, Capability<vola
       uint16_t x0 = logo_x - ((logo_xd > 0) ? logo_xd : 0);
       uint16_t x1 = logo_x1 - ((logo_xd < 0) ? logo_xd : 0);
       // Restore the row to the background colour.
-      fill_rect(spi, gpio, x0, y0, x1, y1, back_pix);
+      fill_rect(spi, x0, y0, x1, y1, back_pix);
     }
 
     // Determine the new position of the logo.

--- a/sw/common/defs.h
+++ b/sw/common/defs.h
@@ -23,7 +23,7 @@
 #define GPIO_ADDRESS (0x8000'0000)
 #define GPIO_RANGE (0x0000'0040)
 
-#define PWM_NUM 6
+#define PWM_NUM 7
 #define PWM_ADDRESS (0x8000'1000)
 #define PWM_BOUNDS (0x0000'0008)
 #define PWM_RANGE (0x0000'0008)

--- a/vendor/display_drivers.lock.hjson
+++ b/vendor/display_drivers.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/engdoreis/display_drivers.git
-    rev: d0ea11852c43bd7db2ba9316e4170b8297a1d6a0
+    rev: 66f87a03b1ef637c80cb507d2b6d556168418e6a
   }
 }

--- a/vendor/display_drivers/st7735/lcd_st7735.c
+++ b/vendor/display_drivers/st7735/lcd_st7735.c
@@ -91,9 +91,9 @@ Result lcd_st7735_init(St7735Context *ctx, LCD_Interface *interface) {
 
 Result lcd_st7735_set_orientation(St7735Context *ctx, LCD_Orientation orientation) {
   const static uint8_t st7735_orientation_map[] = {
-      ST77_MADCTL_MY | ST77_MADCTL_MV,
-      ST77_MADCTL_MX | ST77_MADCTL_MV,
+      ST77_MADCTL_MV | ST77_MADCTL_MX,
       ST77_MADCTL_MX | ST77_MADCTL_MY,
+      ST77_MADCTL_MV | ST77_MADCTL_MY,
       0,
   };
 
@@ -201,13 +201,13 @@ Result lcd_st7735_putchar(St7735Context *ctx, LCD_Point origin, char character) 
 
   set_address(ctx, origin.x, origin.y, origin.x + char_descriptor->width - 1, origin.y + font->height - 1);
   ctx->parent.interface->gpio_write(ctx->parent.interface->handle, false, true);
-  const uint8_t *char_bitmap = &font->bitmap_table[char_descriptor->position - 1];
+  const uint8_t *char_bitmap = &font->bitmap_table[char_descriptor->position];
   for (int row = 0; row < font->height; row++) {
     for (int column = 0; column < char_descriptor->width; column++) {
       uint8_t bit = (uint8_t)(column % 8);
       char_bitmap += (uint8_t)(bit == 0);
       buffer[column] =
-          (uint16_t)((*char_bitmap & (0x01 << bit)) ? ctx->parent.foreground_color : ctx->parent.background_color);
+          (uint16_t)((char_bitmap[-1] & (0x01 << bit)) ? ctx->parent.foreground_color : ctx->parent.background_color);
     }
     write_buffer(ctx, (uint8_t *)buffer, sizeof(buffer));
   }

--- a/vendor/display_drivers/st7735/lcd_st7735_cmds.h
+++ b/vendor/display_drivers/st7735/lcd_st7735_cmds.h
@@ -72,9 +72,9 @@ typedef enum {
 } ST7735_Cmd;
 
 typedef enum {
-  ST77_MADCTL_MX  = 0x01 << 7,  // Column Address Order
-  ST77_MADCTL_MV  = 0x01 << 6,  // Row/Column Exchange
-  ST77_MADCTL_MY  = 0x01 << 5,  // Row Address Order
+  ST77_MADCTL_MY  = 0x01 << 7,  // Row Address Order
+  ST77_MADCTL_MX  = 0x01 << 6,  // Column Address Order
+  ST77_MADCTL_MV  = 0x01 << 5,  // Row/Column Exchange
   ST77_MADCTL_ML  = 0x01 << 4,
   ST77_MADCTL_RGB = 0x01 << 3,
   ST77_MADCTL_MH  = 0x01 << 2


### PR DESCRIPTION
Modify the use of GPIO pins to match hardware changes.

The DPI model of the LCD panel now supports all rendering orientations for other tests in simulation.
Modify the lcd_check code to support operation in landscape orientation and not just portait. This was necessary to assist with bring up of other simulation tests; 3 of the possible 8 orientations are in use.
