### PR TITLE
Make test output formatting more consistent

### DIFF
--- a/sw/cheri/tests/hyperram_tests.hh
+++ b/sw/cheri/tests/hyperram_tests.hh
@@ -269,42 +269,43 @@ void hyperram_tests(CapRoot root, Log &log) {
 
   for (size_t i = 0; i < HYPERRAM_TEST_ITERATIONS; i++) {
     log.println("\nrunning hyperram_test: {} \\ {}", i, HYPERRAM_TEST_ITERATIONS - 1);
-    log.println("HYPERRAM_TEST_SIZE: {:#08x}", HYPERRAM_TEST_SIZE);
-
+    set_console_mode(log, CC_PURPLE);
+    log.println("(HYPERRAM_TEST_SIZE: {:#08x})", HYPERRAM_TEST_SIZE);
+    set_console_mode(log, CC_RESET);
     bool test_failed = false;
     int failures     = 0;
 
-    log.print("Running RND cap test...");
+    log.print("  Running RND cap test...");
     failures = rand_cap_test(hyperram_area, hyperram_cap_area, prng, HYPERRAM_TEST_SIZE);
     test_failed |= (failures > 0);
     write_test_result(log, failures);
 
-    log.print("Running RND data test...");
+    log.print("  Running RND data test...");
     failures = rand_data_test_full(hyperram_area, prng);
     test_failed |= (failures > 0);
     write_test_result(log, failures);
 
-    log.print("Running RND data & address test...");
+    log.print("  Running RND data & address test...");
     failures = rand_data_addr_test(hyperram_area, prng, HYPERRAM_TEST_SIZE);
     test_failed |= (failures > 0);
     write_test_result(log, failures);
 
-    log.print("Running 0101 stripe test...");
+    log.print("  Running 0101 stripe test...");
     failures = stripe_test(hyperram_area, 0x55555555);
     test_failed |= (failures > 0);
     write_test_result(log, failures);
 
-    log.print("Running 1001 stripe test...");
+    log.print("  Running 1001 stripe test...");
     failures = stripe_test(hyperram_area, 0x99999999);
     test_failed |= (failures > 0);
     write_test_result(log, failures);
 
-    log.print("Running 0000_1111 stripe test...");
+    log.print("  Running 0000_1111 stripe test...");
     failures = stripe_test(hyperram_area, 0x0F0F0F0F);
     test_failed |= (failures > 0);
     write_test_result(log, failures);
 
-    log.print("Running Execution test...");
+    log.print("  Running Execution test...");
     failures = execute_test(hyperram_area, prng, HYPERRAM_TEST_SIZE);
     test_failed |= (failures > 0);
     write_test_result(log, failures);

--- a/sw/cheri/tests/uart_tests.hh
+++ b/sw/cheri/tests/uart_tests.hh
@@ -13,6 +13,14 @@
 #include "../common/uart-utils.hh"
 #include "test_runner.hh"
 
+/**
+ * Configures the number of test iterations to perform.
+ * This can be overriden via a compilation flag.
+ */
+#ifndef UART_TEST_ITERATIONS
+#define UART_TEST_ITERATIONS (1U)
+#endif
+
 const char UartLoopbackTestString[] = "test string";
 
 bool uart_loopback_test(UartPtr uart) {
@@ -50,8 +58,22 @@ bool uart_interrupt_state_test(UartPtr uart) {
 void uart_tests(CapRoot root, Log& log) {
   auto uart1 = uart_ptr(root, 1);
 
-  log.println("running uart_loopback_test");
-  check_result(log, uart_loopback_test(uart1));
-  log.println("running uart_interrupt_state_test");
-  check_result(log, uart_interrupt_state_test(uart1));
+  // Execute the specified number of iterations of each test.
+  for (size_t i = 0; i < UART_TEST_ITERATIONS; i++) {
+    log.println("\r\nrunning uart_test: {} \\ {}", i, UART_TEST_ITERATIONS - 1);
+    bool test_failed = false;
+    int failures     = 0;
+
+    log.print("  Running UART Loopback test... ");
+    failures = !uart_loopback_test(uart1);
+    test_failed |= (failures > 0);
+    write_test_result(log, failures);
+
+    log.print("  Running UART Interrupt State test... ");
+    failures = !uart_interrupt_state_test(uart1);
+    test_failed |= (failures > 0);
+    write_test_result(log, failures);
+
+    check_result(log, !test_failed);
+  }
 }

--- a/sw/cheri/tests/usbdev_tests.hh
+++ b/sw/cheri/tests/usbdev_tests.hh
@@ -107,7 +107,7 @@ void usbdev_tests(CapRoot root, Log &log) {
 
   // Execute the specified number of iterations of each test
   for (size_t i = 0; i < USBDEV_TEST_ITERATIONS; i++) {
-    log.println("\n\nrunning usbdev_test: {} \\ {}", i, USBDEV_TEST_ITERATIONS - 1);
+    log.println("\r\nrunning usbdev_test: {} \\ {}", i, USBDEV_TEST_ITERATIONS - 1);
     set_console_mode(log, CC_PURPLE);
     log.println("(needs User USB connected to a Type-A USB host port)");
     set_console_mode(log, CC_RESET);


### PR DESCRIPTION
This PR contains changes to a few tests to make the formatting of the test output more consistent and cohesive. This also makes it easier to identify failures in the PLIC tests by adding explicit coloured `PASS`/`FAIL` messages to the end of each interrupt log. It also adds the ability to modify the number of test iterations for older tests that did not previously support this feature (PLIC and UART). See the commit messages for more details.

This PR primarily changes the output formatting and adds the ability to run multiple iterations; it should not change the functionality of the tests themselves.