### PR TITLE
OpenOCD solve deprecation warnings

### DIFF
--- a/util/sonata-openocd-cfg.tcl
+++ b/util/sonata-openocd-cfg.tcl
@@ -5,9 +5,9 @@
 adapter driver ftdi
 transport select jtag
 
-ftdi_vid_pid 0x0403 0x6011
-ftdi_channel 1
-ftdi_layout_init 0x0088 0x008b
+ftdi vid_pid 0x0403 0x6011
+ftdi channel 1
+ftdi layout_init 0x0088 0x008b
 
 # Configure JTAG chain and the target processor
 set _CHIPNAME riscv


### PR DESCRIPTION
This solves three deprecation warnings when running the memory helper utility script.