### PR TITLE
[rtl] Add register stage to SPI internal loopback

### DIFF
--- a/rtl/ip/spi/rtl/spi.sv
+++ b/rtl/ip/spi/rtl/spi.sv
@@ -187,7 +187,13 @@ module spi import spi_reg_pkg::*; #(
   // Internal loopback functionality allowing the input (CIPO) to be received directly from
   // the output (COPI) for testing.
   logic spi_cipo;
-  assign spi_cipo = reg2hw.control.int_loopback.q ? spi_copi_o : spi_cipo_i;
+  logic spi_copi_q;
+
+  always_ff @(posedge clk_i) begin
+    spi_copi_q <= spi_copi_o;
+  end
+
+  assign spi_cipo = reg2hw.control.int_loopback.q ? spi_copi_q : spi_cipo_i;
 
   spi_core u_spi_core (
     .clk_i,

--- a/sw/cheri/tests/spi_tests.hh
+++ b/sw/cheri/tests/spi_tests.hh
@@ -417,7 +417,9 @@ int spi_irq_test(SpiPtr spi, ds::xoroshiro::P32R8 &prng, Log &log) {
  */
 int spi_loopback_test(SpiPtr spi, bool external, bool cpol, bool cpha, bool msb_first, ds::xoroshiro::P32R8 &prng,
                       Log &log) {
-  constexpr uint32_t kSpiSpeed = 0u;  // Let's go as fast as possible.
+  // Register stage in internal loopback means this is the fastest possible
+  // speed.
+  constexpr uint32_t kSpiSpeed = 1u;
   // Take a copy of the PRNG so that we can predict the read-side data.
   ds::xoroshiro::P32R8 read_prng = prng;
   size_t bytes_read              = 0u;


### PR DESCRIPTION
Timing failures have been observed on this loopback path, it has minimal logic levels but a very long delay, possibly due to I/O timing constraints.

Adding the register stage cuts the internal path. With the register stage the internal loopback cannot run at full speed, however as this is for testing purposes only this is acceptable.

Bizarrely causes timing failures to introduce this right now, so not to be merged yet until we get on top of the timing instability.