### PR TITLE
Resurrect SD card operation

### DIFF
--- a/data/pins_sonata.xdc
+++ b/data/pins_sonata.xdc
@@ -291,6 +291,7 @@ set_property -dict { PACKAGE_PIN C10 IOSTANDARD LVCMOS33 } [get_ports appspi_d1]
 set_property -dict { PACKAGE_PIN A10 IOSTANDARD LVCMOS33 } [get_ports appspi_d2]
 set_property -dict { PACKAGE_PIN A9  IOSTANDARD LVCMOS33 } [get_ports appspi_d3]
 set_property -dict { PACKAGE_PIN D10 IOSTANDARD LVCMOS33 } [get_ports appspi_cs]
+set_property PULLTYPE PULLUP [get_ports appspi_d1]
 
 ## Ethernet MAC
 set_property -dict { PACKAGE_PIN J5  IOSTANDARD LVCMOS18 } [get_ports ethmac_rst]

--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -261,10 +261,7 @@ module top_sonata
   logic [23:0] unused_gp_o;
 
   wire spi_board_copi;
-  wire spi_board_cipo;
   wire spi_board_sclk;
-
-  assign spi_board_cipo = &{appspi_d1, microsd_dat0};
 
   assign {appspi_d0,   appspi_clk}   = {spi_board_copi, spi_board_sclk};
   assign {microsd_cmd, microsd_clk}  = {spi_board_copi, spi_board_sclk};
@@ -317,7 +314,8 @@ module top_sonata
 
     // Non-pinmuxed spi devices
     .spi_board_copi_o        (spi_board_copi),
-    .spi_board_cipo_i        (spi_board_cipo),
+    .spi_board_flash_cipo_i  (appspi_d1),
+    .spi_board_microsd_cipo_i(microsd_dat0),
     .spi_board_sclk_o        (spi_board_sclk),
     .spi_board_flash_cs_o    (appspi_cs),
     .spi_board_microsd_cs_o  (microsd_dat3),

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -42,7 +42,8 @@ module sonata_system
 
   // Non-pinmuxed spi devices
   output logic                     spi_board_copi_o,
-  input  logic                     spi_board_cipo_i,
+  input  logic                     spi_board_flash_cipo_i,
+  input  logic                     spi_board_microsd_cipo_i,
   output logic                     spi_board_sclk_o,
   output logic                     spi_board_flash_cs_o,
   output logic                     spi_board_microsd_cs_o,
@@ -1069,6 +1070,11 @@ module sonata_system
     .intr_av_setup_empty_o        (usbdev_interrupts[17])
   );
 
+  // Combine the CIPO lines from the Flash memory and the microSD card to the
+  // first dedicated SPI controller; CIPO line should only be driven by the
+  // peripheral whilst the corresponding Chip Select line is asserted, active low.
+  wire spi_board_cipo = &{spi_board_microsd_cipo_i | spi_board_microsd_cs_o,
+                          spi_board_flash_cipo_i   | spi_board_flash_cs_o};
 
   // Dedicated Spi Controllers
   // - Flash memory & microSD
@@ -1093,7 +1099,7 @@ module sonata_system
 
     // SPI signals.
     .spi_copi_o          (spi_board_copi_o),
-    .spi_cipo_i          (spi_board_cipo_i),
+    .spi_cipo_i          (spi_board_cipo),
     .spi_cs_o            ({spi_board_microsd_cs_o, spi_board_flash_cs_o}),
     .spi_clk_o           (spi_board_sclk_o)
   );


### PR DESCRIPTION
Combining CIPO lines directly without regard to Chip Selects is risky, and in particular the line `appspi_d1` from the flash is tri-stated without a pullup resistor on the FPGA board.

Modifications to the top_verilator implmentation to match the top_sonata implementation more closely, and paving the way for the introduction of the microSD card DPI model (already built and operational).


_Without these changes the flash works only by virtue of the fact the the Sonata FPGA board carries a pullup on microSD card CIPO line, and the SD card is unusable because the flash CIPO does not. With these changes in place, and appropriate updates to the software that drives the microSD card and LCD, both the reading of SD card filing systems and the basic video player are operational once more._

@elliotb-lowrisc FPGA build remains timing clean (v2022.2), but it would be worth giving it the once over, please.