### PR TITLE
Fix SPI controller interrupt routing

### DIFF
--- a/rtl/ip/spi/rtl/spi.sv
+++ b/rtl/ip/spi/rtl/spi.sv
@@ -159,12 +159,12 @@ module spi import spi_reg_pkg::*; #(
   // Status-type FIFO-related interrupts.
   logic rx_fifo_ge_watermark, tx_fifo_empty, tx_fifo_le_watermark;
   assign tx_fifo_empty = ~|tx_fifo_depth;
-  // Tx FIFO level at or above programmed watermark (1,2,4,8,16,32,56)
+  // Rx FIFO level at or above programmed watermark (1,2,4,8,16,32,56)
   always_comb begin
     if (reg2hw.control.rx_watermark.q == 4'h6) rx_fifo_ge_watermark = (rx_fifo_depth_w >= 8'd56);
     else rx_fifo_ge_watermark = |(rx_fifo_depth_w >> reg2hw.control.rx_watermark.q);
   end
-  // Rx FIFO level at or below programmed watermark (1,2,4,8,16)
+  // Tx FIFO level at or below programmed watermark (1,2,4,8,16)
   assign tx_fifo_le_watermark = (tx_fifo_depth_w == (8'h1 << reg2hw.control.tx_watermark.q)) ||
                               ~|(tx_fifo_depth_w >> reg2hw.control.tx_watermark.q);
 

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -172,7 +172,7 @@ module sonata_system
   // Each IP block has a single interrupt line to the PLIC and software shall consult the intr_state
   // register within the block itself to identify the interrupt source(s).
   logic [I2C_NUM-1:0]  i2c_irq;
-  logic [SPI_NUM-1:0]  spi_irq;
+  logic [SPI_NUM+2:0]  spi_irq;
   logic [UART_NUM-1:0] uart_irq;
   logic                usbdev_irq;
 
@@ -185,8 +185,9 @@ module sonata_system
     for (int i = 0; i < I2C_NUM; i++) begin
       i2c_irq[i] = |i2c_interrupts[i];
     end
-    // Single interrupt line per SPI controller.
-    for (int i = 0; i < SPI_NUM; i++) begin
+    // Single interrupt line per SPI controller; there are 3 dedicated SPI controllers
+    // for the on-board peripherals.
+    for (int i = 0; i < SPI_NUM + 3; i++) begin
       spi_irq[i] = |spi_interrupts[i];
     end
     // Single interrupt line for USBDEV.
@@ -195,8 +196,8 @@ module sonata_system
 
   logic [31:0] intr_vector;
 
-  assign intr_vector[31 : SPI_NUM + 24] = 'b0;      // Support up to 8 SPI controllers.
-  assign intr_vector[SPI_NUM + 23 : 24] = spi_irq;
+  assign intr_vector[31 : SPI_NUM + 27] = 'b0;      // Support up to 8 SPI controllers.
+  assign intr_vector[SPI_NUM + 26 : 24] = spi_irq;
   assign intr_vector[23 : I2C_NUM + 16] = 'b0;      // Support up to 8 I2C blocks.
   assign intr_vector[I2C_NUM + 15 : 16] = i2c_irq;
   assign intr_vector[15 : UART_NUM + 8] = 'b0;


### PR DESCRIPTION
With the semantic change to the `SPI_NUM` parameter, the final 3 SPI controllers lost their ability to stimulate the PLIC. Correct the wiring.

(Built into FPGA on top of PR #323 and timing-clean; tests/test_runner passing.)