### PR TITLE
Updated to latest RTOS fork and lowrisc-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -395,11 +395,11 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1727339002,
-        "narHash": "sha256-h/daSpZNRs+HkUMAEQwqTs/GHrcIYo+ZPUEaghuAfeY=",
+        "lastModified": 1729160096,
+        "narHash": "sha256-Mb201UMO84FrhcQAxDf73eqgJbeVWF7zfJxJrb9GL8U=",
         "owner": "lowRISC",
         "repo": "lowrisc-nix",
-        "rev": "674b4548fa7efd573aba2efba2abc98dcdb02854",
+        "rev": "7e387a147e477160aaf6343ce0233dc1ee2ceede",
         "type": "github"
       },
       "original": {

--- a/nix/software.nix
+++ b/nix/software.nix
@@ -11,9 +11,9 @@
   cheriotRtosSource = pkgs.fetchFromGitHub {
     owner = "lowRISC";
     repo = "CHERIoT-RTOS";
-    rev = "8fbbda7b0ee528764892e1add9b539f9ec9064b0";
+    rev = "89fc2a3cb8e9fcaed84ac835ad32a89309523e35";
     fetchSubmodules = true;
-    hash = "sha256-uIZoEKmsyVzYldDv37p/zh1vtnQzKmw+wg+yctpyqa8=";
+    hash = "sha256-ri1VvryCNGWFatTIuEHqtx91taJ4CiW+5BcQcxPPeWM=";
   };
 
   reisfmtSource = pkgs.fetchFromGitHub {

--- a/sw/cheri/CMakeLists.txt
+++ b/sw/cheri/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 
 FetchContent_Declare(CHERIOT_RTOS
   GIT_REPOSITORY    https://github.com/lowRISC/CHERIoT-RTOS
-  GIT_TAG           8fbbda7b0ee528764892e1add9b539f9ec9064b0
+  GIT_TAG           89fc2a3cb8e9fcaed84ac835ad32a89309523e35
 )
 
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)

--- a/sw/cheri/checks/usbdev_check.cc
+++ b/sw/cheri/checks/usbdev_check.cc
@@ -40,17 +40,17 @@ static void write_strn(UartPtr uart, const char *str, size_t len) {
 static const uint8_t _Alignas(uint32_t) signon[] = "Hello from CHERI USB!\r\n";
 
 // Device Descriptor; see "Table 9-8. Standard Device Descriptor"
-static const uint8_t _Alignas(uint32_t) dev_dscr[] = {0x12u, 1,    0,    2,    0, 0, 0, OpenTitanUsbdev::MaxPacketLen,
-                                                      0xd1,  0x18, 0x3a, 0x50,  // Google lowRISC generic FS USB
-                                                      0,     1,    0,    0,    0, 1};
+static const uint8_t _Alignas(uint32_t) dev_dscr[] = {
+    0x12u, 1, 0, 2, 0, 0, 0, OpenTitanUsbdev::MaxPacketLength, 0xd1, 0x18, 0x3a, 0x50,  // Google lowRISC generic FS USB
+    0,     1, 0, 0, 0, 1};
 
 // Configuration Descriptor; see "Table 9-10. Standard Configuration Descriptor"
 static const uint8_t _Alignas(uint32_t) cfg_dscr[] = {
     // Present a single interface consisting of an IN EP and and OUT EP.
     USB_CFG_DSCR_HEAD(USB_CFG_DSCR_LEN + (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN), 1),
     VEND_INTERFACE_DSCR(0, 2, 0x50, 1),
-    USB_BULK_EP_DSCR(0, 1, OpenTitanUsbdev::MaxPacketLen, 0),
-    USB_BULK_EP_DSCR(1, 1, OpenTitanUsbdev::MaxPacketLen, 4),
+    USB_BULK_EP_DSCR(0, 1, OpenTitanUsbdev::MaxPacketLength, 0),
+    USB_BULK_EP_DSCR(1, 1, OpenTitanUsbdev::MaxPacketLength, 4),
 };
 
 // Default test descriptor; required by the USB DPI model and retrieved using a Vendor Specific
@@ -67,7 +67,7 @@ static void rxCallback(void *rxHandle, uint8_t ep, bool setup, const uint8_t *da
 
 [[noreturn]] extern "C" void entry_point(void *rwRoot) {
   // Buffer for data transfer to/from the USB device.
-  //  uint8_t _Alignas(uint32_t) data[OpenTitanUsbdev::MaxPacketLen];
+  //  uint8_t _Alignas(uint32_t) data[OpenTitanUsbdev::MaxPacketLength];
 
   Capability<void> root{rwRoot};
 

--- a/sw/cheri/tests/plic_tests.hh
+++ b/sw/cheri/tests/plic_tests.hh
@@ -248,44 +248,44 @@ struct PlicTest {
     instance = 0;
 
     struct usbdev_irq {
-      OpenTitanUsbdev::OpenTitanUsbdevInterrupt id;
+      OpenTitanUsbdev::UsbdevInterrupt id;
       bool can_clear;
     };
     static constexpr std::array<usbdev_irq, 18> usbdevMap = {{
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptDisconnected, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptHostLost, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptLinkReset, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptLinkSuspend, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptLinkResume, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptAvBufferOverflow, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptLinkInError, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptCrcError, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptPidError, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptBitstuffError, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptFrame, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptPowered, true},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptLinkOutError, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::Disconnected, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::HostLost, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::LinkReset, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::LinkSuspend, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::LinkResume, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::AvailableBufferOverflow, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::LinkInError, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::RedundancyCheckError, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::PacketIdentifierError, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::BitstuffingError, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::FrameUpdated, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::Powered, true},
+        {OpenTitanUsbdev::UsbdevInterrupt::LinkOutError, true},
 
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptPacketReceived, false},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptPacketSent, false},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptRecvFifoFull, false},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptAvOutBufferEmpty, false},
-        {OpenTitanUsbdev::OpenTitanUsbdevInterrupt::InterruptAvSetupBufferEmpty, false},
+        {OpenTitanUsbdev::UsbdevInterrupt::PacketReceived, false},
+        {OpenTitanUsbdev::UsbdevInterrupt::PacketSent, false},
+        {OpenTitanUsbdev::UsbdevInterrupt::ReceiveFull, false},
+        {OpenTitanUsbdev::UsbdevInterrupt::AvailableOutEmpty, false},
+        {OpenTitanUsbdev::UsbdevInterrupt::AvailableSetupEmpty, false},
     }};
 
     auto usbdev = usbdev_ptr(root);
 
     // Ensure that initially all interrupts are cleared and disabled.
-    usbdev->interrupt_disable(static_cast<OpenTitanUsbdev::OpenTitanUsbdevInterrupt>(~0u));
+    usbdev->interrupt_disable(static_cast<OpenTitanUsbdev::UsbdevInterrupt>(~0u));
     usbdev->interruptState = ~0u;
     usbdev->interruptTest  = 0u;
 
     log_->println("  Testing USBDEV:");
     for (size_t i = 0; i < usbdevMap.size(); ++i) {
-      ip_irq_id        = usbdevMap[i].id;
+      ip_irq_id        = static_cast<uint32_t>(usbdevMap[i].id);
       is_irq_clearable = usbdevMap[i].can_clear;
       plic_irq_id      = static_cast<PLIC::Interrupts>(PLIC::Interrupts::Usbdev + instance);
-      exp_intr_state   = usbdevMap[i].id;
+      exp_intr_state   = static_cast<uint32_t>(usbdevMap[i].id);
 
       // Register interrupt handler.
       irq_handler = [](PlicTest *plic_test, PLIC::Interrupts irq) {
@@ -314,7 +314,7 @@ struct PlicTest {
       usbdev->interruptTest = 0;
     }
     // Disable interrupt to prevent interference with other tests.
-    usbdev->interrupt_disable(static_cast<OpenTitanUsbdev::OpenTitanUsbdevInterrupt>(ip_irq_id));
+    usbdev->interrupt_disable(static_cast<OpenTitanUsbdev::UsbdevInterrupt>(ip_irq_id));
   }
 
   // Wait with timeout until an interrupt occurs, logging any mismatch.

--- a/sw/cheri/tests/usbdev_tests.hh
+++ b/sw/cheri/tests/usbdev_tests.hh
@@ -29,15 +29,15 @@ using namespace CHERI;
 
 // Device Descriptor; see "Table 9-8. Standard Device Descriptor"
 static const uint8_t _Alignas(uint32_t) deviceDescriptor[] = {
-    0x12u, 1, 0, 2, 0, 0, 0, OpenTitanUsbdev::MaxPacketLen, 0xd1, 0x18, 0x3a, 0x50, 0, 1, 0, 0, 0, 1};
+    0x12u, 1, 0, 2, 0, 0, 0, OpenTitanUsbdev::MaxPacketLength, 0xd1, 0x18, 0x3a, 0x50, 0, 1, 0, 0, 0, 1};
 
 // Configuration Descriptor; see "Table 9-10. Standard Configuration Descriptor"
 static const uint8_t _Alignas(uint32_t) configDescriptor[] = {
     // Present a single interface consisting of an IN EP and and OUT EP.
     USB_CFG_DSCR_HEAD(USB_CFG_DSCR_LEN + (USB_INTERFACE_DSCR_LEN + 2 * USB_EP_DSCR_LEN), 1),
     VEND_INTERFACE_DSCR(0, 2, 0x50, 1),
-    USB_BULK_EP_DSCR(0, 1, OpenTitanUsbdev::MaxPacketLen, 0),
-    USB_BULK_EP_DSCR(1, 1, OpenTitanUsbdev::MaxPacketLen, 4),
+    USB_BULK_EP_DSCR(0, 1, OpenTitanUsbdev::MaxPacketLength, 0),
+    USB_BULK_EP_DSCR(1, 1, OpenTitanUsbdev::MaxPacketLength, 4),
 };
 
 // Default test descriptor; required by the USB DPI model and retrieved using a


### PR DESCRIPTION
- Updated to latest version of lowRISC RTOS fork
- Updated lowrisc-nix version
  - We'll need the latest version of the compiler to be able to build the
upstream CHERIoT RTOS.