### PR TITLE
Ensure mikroBUS Click RST/RE pin is driven

### DIFF
--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -379,6 +379,11 @@ module top_sonata
   assign led_legacy = ~cheri_en;
   assign led_halted = 1'b0;
 
+  // mikroBUS Click boards mostly use this pin as an active low reset signal but some
+  // boards use it as an active low Read Enable (RE) pin; presently this pin is not
+  // under software control so some boards are not supported.
+  assign mb0 = 1'b1;
+
   // Produce 50 MHz system clock from 25 MHz Sonata board clock.
   clkgen_sonata #(
     .SysClkFreq(SysClkFreq),


### PR DESCRIPTION
This RST pin is an active low reset signal to most mikroBUS Click boards, but some boards use it as an active low Read Enable (RE) pin, so presently not all boards are supported.

Avoid producing undefined behaviour on (hopefully) the majority of boards, and rely upon power-cycling and software-reset mechanisms.