### PR TITLE
Report correct GPIO num on sysinfo

### DIFF
--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -119,6 +119,8 @@ module sonata_system
   localparam int unsigned TRegAddrWidth = 16; // Timer uses more address bits.
   localparam int unsigned FixedSpiNum   = 2; // Number of SPI devices that don't pass through the pinmux
   localparam int unsigned TotalSpiNum   = SPI_NUM + FixedSpiNum; // The total number of SPI devices
+  localparam int unsigned FixedGpioNum  = 1; // Number of GPIO instances that don't pass through the pinmux
+  localparam int unsigned TotalGpioNum  = GPIO_NUM + FixedGpioNum; // The total number of GPIO instances
 
   // The number of data bits controlled by each mask bit; since the CPU requires
   // only byte level access, explicitly grouping the data bits makes the inferred
@@ -850,9 +852,9 @@ module sonata_system
   // 1: Raspberry Pi HAT
   // 2: Arduino Shield
   // 3: Pmod
-  logic [GPIO_IOS_WIDTH-1:0] gpio_from_pins     [GPIO_NUM + 1];
-  logic [GPIO_IOS_WIDTH-1:0] gpio_to_pins       [GPIO_NUM + 1];
-  logic [GPIO_IOS_WIDTH-1:0] gpio_to_pins_enable[GPIO_NUM + 1];
+  logic [GPIO_IOS_WIDTH-1:0] gpio_from_pins     [TotalGpioNum];
+  logic [GPIO_IOS_WIDTH-1:0] gpio_to_pins       [TotalGpioNum];
+  logic [GPIO_IOS_WIDTH-1:0] gpio_to_pins_enable[TotalGpioNum];
 
   assign gpio_from_pins[0] = gp_i;
   assign gp_o              = gpio_to_pins       [0];
@@ -861,7 +863,7 @@ module sonata_system
   gpio #(
     .GpiWidth     ( GPIO_IOS_WIDTH ),
     .GpoWidth     ( GPIO_IOS_WIDTH ),
-    .NumInstances ( GPIO_NUM + 1   )
+    .NumInstances ( TotalGpioNum   )
   ) u_gpio (
     .clk_i           (clk_sys_i),
     .rst_ni          (rst_sys_ni),
@@ -1245,11 +1247,11 @@ module sonata_system
   );
 
   system_info #(
-    .SysClkFreq (  SysClkFreq ),
-    .GpioNum    (    GPIO_NUM ),
-    .UartNum    (    UART_NUM ),
-    .I2cNum     (     I2C_NUM ),
-    .SpiNum     ( TotalSpiNum )
+    .SysClkFreq (   SysClkFreq ),
+    .GpioNum    ( TotalGpioNum ),
+    .UartNum    (     UART_NUM ),
+    .I2cNum     (      I2C_NUM ),
+    .SpiNum     (  TotalSpiNum )
   ) u_system_info (
     .clk_i  (clk_sys_i),
     .rst_ni (rst_sys_ni),


### PR DESCRIPTION
Currently, `checks/system_info_check` is reporting the following on the pre-release build:
```
Hash is equal to:
8a5c4ab93c4ee930 clean
System clock frequency: 0x02625a00
GPIO instances: 0x00000005
UART instances: 0x00000003
I2C instances: 0x00000002
SPI instances: 0x00000005
```

But we actually have 6 GPIO instances: general (board), Rasberry Pi HAT, Arduino Shield, PMOD0, PMOD1 and PMODC. This was being under-reported.

The number of GPIO instances in the sysinfo block was being under-reported by 1, because the dedicated general board GPIO that is not passing through pinmux was not counted in the Pinmux `GPIO_NUM` parameter. This PR replaces instances of `GPIO_NUM+1` in the code with a localparam `TotalGpioNum` in the same vein as the recent SPI changes, and fixes this instance of undercounting the GPIO. This should help prevent future issues from mismatches due to changes not being synchronised elsewhere in the code.