### PR TITLE
Application flash has moved; update spi_test

### DIFF
--- a/sw/cheri/checks/spi_test.cc
+++ b/sw/cheri/checks/spi_test.cc
@@ -37,7 +37,7 @@ using namespace CHERI;
   uart.bounds()                           = UART_BOUNDS;
 
   Capability<volatile SonataSpi> spi = root.cast<volatile SonataSpi>();
-  spi.address()                      = SPI_ADDRESS;
+  spi.address()                      = SPI_ADDRESS + 2 * SPI_RANGE;
   spi.bounds()                       = SPI_BOUNDS;
 
   SpiFlash spi_flash(spi);


### PR DESCRIPTION
SPI controller 2 (now once again through pinmux) drives the application flash; update spi_test to use the correct controller.
Tested and once again producing correct output.