### PR TITLE
Python requirement serial should be pyserial

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -13,8 +13,8 @@ packaging
 poetry
 pycryptodome
 pydantic
+pyserial
 semantic_version
-serial
 setuptools
 tabulate
 toml


### PR DESCRIPTION
This dependency is necessary for the test runner.