### PR TITLE
Connect arduino shield pin 9 to correct PWM channel

### DIFF
--- a/data/top_config.toml
+++ b/data/top_config.toml
@@ -341,7 +341,7 @@ block_ios = [{block = "gpio", instance = 1, io = "ios", io_index = 8}]
 name = "ah_tmpio9"
 block_ios = [
   {block = "gpio", instance = 1, io = "ios", io_index = 9},
-  {block = "pwm", instance = 0, io = "out", io_index = 2},
+  {block = "pwm", instance = 0, io = "out", io_index = 3},
 ]
 
 [[pins]]

--- a/doc/ip/pinmux/README.md
+++ b/doc/ip/pinmux/README.md
@@ -57,7 +57,7 @@ The default value for all of these selectors is `'b10`.
 | 0x02a | `ah_tmpio6` | 0, `gpio[1].ios[6]`, `pwm_out[2]` |
 | 0x02b | `ah_tmpio7` | 0, `gpio[1].ios[7]` |
 | 0x02c | `ah_tmpio8` | 0, `gpio[1].ios[8]` |
-| 0x02d | `ah_tmpio9` | 0, `gpio[1].ios[9]`, `pwm_out[2]` |
+| 0x02d | `ah_tmpio9` | 0, `gpio[1].ios[9]`, `pwm_out[3]` |
 | 0x02e | `ah_tmpio10` | 0, `spi[1].cs[3]`, `gpio[1].ios[10]`, `pwm_out[4]` |
 | 0x02f | `ah_tmpio11` | 0, `spi[1].copi`, `gpio[1].ios[11]`, `pwm_out[5]` |
 | 0x030 | `ah_tmpio12` | 0, `gpio[1].ios[12]` |

--- a/rtl/system/pinmux.sv
+++ b/rtl/system/pinmux.sv
@@ -2343,7 +2343,7 @@ module pinmux
     .in_i({
       1'b0, // This is set to Z later when output enable is low.
       gpio_ios_i[1][9],
-      pwm_out_i[0][2]
+      pwm_out_i[0][3]
     }),
     .sel_i(ah_tmpio9_sel),
     .out_o(inout_to_pins_o[INOUT_PIN_AH_TMPIO9])
@@ -2358,7 +2358,7 @@ module pinmux
     .in_i({
       1'b0,
       gpio_ios_en_i[1][9],
-      pwm_out_en_i[0][2]
+      pwm_out_en_i[0][3]
     }),
     .sel_i(ah_tmpio9_sel),
     .out_o(inout_to_pins_en_o[INOUT_PIN_AH_TMPIO9])


### PR DESCRIPTION
Previously both pin 6 and 9 were connected to PWM channel 2