### PR TITLE
Simulator boot stub for SRAM added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 # FuseSoC and Sofware builds are placed in build
 build/
 sw/cheri/sim_boot_stub/sim_boot_stub
+sw/cheri/sim_boot_stub/sim_sram_boot_stub
 
 # Nix based builds a placed are symlinked to result
 result

--- a/sw/cheri/sim_boot_stub/Makefile
+++ b/sw/cheri/sim_boot_stub/Makefile
@@ -4,9 +4,14 @@
 CFLAGS=-target riscv32-unknown-unknown -mcpu=cheriot -mabi=cheriot \
 	-mxcheri-rvc -mrelax -fshort-wchar -nodefaultlibs
 
+all: sim_boot_stub sim_sram_boot_stub
+
 sim_boot_stub: boot.S link.ld
 	clang ${CFLAGS} -Tlink.ld -o sim_boot_stub boot.S
 
+sim_sram_boot_stub: boot_sram.S link.ld
+	clang ${CFLAGS} -Tlink.ld -o sim_sram_boot_stub boot_sram.S
+
 .PHONY: clean
 clean:
-	rm sim_boot_stub
+	rm sim_boot_stub sim_sram_boot_stub

--- a/sw/cheri/sim_boot_stub/boot.S
+++ b/sw/cheri/sim_boot_stub/boot.S
@@ -1,16 +1,20 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-	.section .text.start, "ax", @progbits
-.zero 0x80
+  .section .text.start, "ax", @progbits
+  .zero 0x80
 
-	.globl start
-	.p2align 2
-    .type start,@function
+  .globl start
+  .p2align 2
+  .type start,@function
+
+#define HYPERRAM_BASE 0x40000000
+
 start:
   // Enable the ICache
   csrsi            0x7c0, 1
   auipcc           ct1, 0
-  li               t0, 0x40000000
+  // Jump to HyperRAM to start executing
+  li               t0, HYPERRAM_BASE
   csetaddr         ct1, ct1, t0
   cjr              ct1

--- a/sw/cheri/sim_boot_stub/boot_sram.S
+++ b/sw/cheri/sim_boot_stub/boot_sram.S
@@ -1,0 +1,20 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+  .section .text.start, "ax", @progbits
+  .zero 0x80
+
+  .globl start
+  .p2align 2
+  .type start,@function
+
+#define SRAM_BASE 0x00101000
+
+start:
+  // Enable the ICache
+  csrsi            0x7c0, 1
+  auipcc           ct1, 0
+  # Jumping to the start of code in SRAM located at 0x00101000 by default.
+  li               t0, SRAM_BASE
+  csetaddr         ct1, ct1, t0
+  cjr              ct1


### PR DESCRIPTION
This boot stub is useful for SRAM only examples like the ones in the current upstream RTOS.