### PR TITLE
ci: stop pinning NixOS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       working-directory: sw/legacy/build
 
   simulator:
-    runs-on: nixos-24.05
+    runs-on: nixos
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,7 +27,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: nixos-24.05
+    runs-on: nixos
     steps:
       - name: Install Nix
         uses: cachix/install-nix-action@v27


### PR DESCRIPTION
This would allow easier NixOS updates of the runner machine.