### PR TITLE
Fix only PWM 0 being enabled via Pinmux

### DIFF
--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -1208,8 +1208,8 @@ module sonata_system
     .clk_i(clk_sys_i),
     .rst_ni(rst_sys_ni),
 
-    .pwm_out_i('{pwm_modulated}),
-    .pwm_out_en_i('{'b1}),
+    .pwm_out_i('{PWM_NUM{pwm_modulated}}),
+    .pwm_out_en_i('{PWM_NUM{{PWM_OUT_WIDTH{1'b1}}}}),
 
     .uart_rx_o(uart_rx),
     .uart_tx_i(uart_tx),


### PR DESCRIPTION
Currently, all the PWMs (minus the LCD backlight) are being routed through pinmux, but the value being passed for the PWM output enable is the constant `'{'b1}'`. Because the inner value is `'b1`, this is extended to fill the 7 bit PWM output range as `0000001`, instead of using `'1` which would extend to `1111111`. Hence, to fix this, we would want to use the value `'{'1}` instead. 

Thanks to @elliotb-lowrisc who came up with a slightly more robust and comprehensible alternative, where we more explicitly cast/extend these values to match the output size and module count. These changes should probably be propagated to the other port connections (e.g. SPI), but are isolated to just PWM for this PR to keep this PR focused on fixing the bug. This ensures that all outputs of all PWM devices are now enabled through pinmux.

I've tested this fix makes the correct values appear on the waveforms in simulation, and I've built a bitstream and tested muxing `pwm_out_1` to `PMOD0_2` and using a digtal multimeter to read a range of values, which wasn't working previously. The code snippet used for testing is as below:
```cpp
	auto pinmux = SonataPinmux();
	auto pwm = MMIO_CAPABILITY(SonataPwm, pwm);

	pinmux.output_pin_select(SonataPinmux::OutputPin::pmod0_2, 3); // Pinmux PMOD0_2 to PWM_OUT_1
	pwm->output_set(1, 255, 255);
``` 