### PR TITLE
Add Pinmux PWM test

### DIFF
--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -275,19 +275,21 @@ module top_verilator (input logic clk_i, rst_ni);
   // these signals are re-timed through a single register stage simply to prevent Verilator
   // warnings about circular combinational logic which assesses circularity at the net level
   // (i.e. `in_from_pins` and `out_to_pins`) rather than the bit level.
-  reg [4:0] loopback_q;
+  reg [5:0] loopback_q;
   always @(posedge clk_i) begin
     loopback_q <= {inout_to_pins[INOUT_PIN_AH_TMPIO8],
                    inout_to_pins[INOUT_PIN_AH_TMPIO1],
                    out_to_pins[OUT_PIN_MB10],  // mikroBUS CLick PWM -> PMOD0.1; PWM loopback
                    out_to_pins[OUT_PIN_MB7],   // mikroBUS Click TX -> RX; UART loopback.
-                   out_to_pins[OUT_PIN_MB4]};  // mikroBUS Click COPI -> CIPO; SPI loopback.
+                   out_to_pins[OUT_PIN_MB4],  // mikroBUS Click COPI -> CIPO; SPI loopback.
+                   inout_to_pins[INOUT_PIN_PMOD0_8]}; // PMOD0 8->10; PWM loopback
   end
   assign {inout_from_pins[INOUT_PIN_AH_TMPIO9],
           inout_from_pins[INOUT_PIN_AH_TMPIO0],
           inout_from_pins[INOUT_PIN_PMOD0_1],
           in_from_pins[IN_PIN_MB8],
-          in_from_pins[IN_PIN_MB3]} = loopback_q;
+          in_from_pins[IN_PIN_MB3],
+          inout_from_pins[INOUT_PIN_PMOD0_10]} = loopback_q;
 
   // Switch inputs have pull-ups and switches pull to ground when on, but in `top_sonata`
   // they are inverted, so 0 here means 'not pressed' or 'off'.

--- a/sw/cheri/common/sonata-devices.hh
+++ b/sw/cheri/common/sonata-devices.hh
@@ -14,6 +14,7 @@
 
 #include <cheri.hh>
 #include <platform-gpio.hh>
+#include <platform-pwm.hh>
 #include <platform-uart.hh>
 #include <platform-i2c.hh>
 #include <platform-spi.hh>
@@ -22,6 +23,7 @@
 
 typedef CHERI::Capability<void> CapRoot;
 typedef volatile SonataGpioBoard *GpioPtr;
+typedef volatile SonataPwm *PwmPtr;
 typedef volatile OpenTitanUart *UartPtr;
 typedef volatile OpenTitanUsbdev *UsbdevPtr;
 typedef volatile OpenTitanI2c *I2cPtr;
@@ -38,6 +40,13 @@ using PinmuxPtrs = std::pair<PinSinksPtr, BlockSinksPtr>;
   gpio.address()                                   = GPIO_ADDRESS;
   gpio.bounds()                                    = GPIO_BOUNDS;
   return gpio;
+}
+
+[[maybe_unused]] static PwmPtr pwm_ptr(CapRoot root) {
+  CHERI::Capability<volatile SonataPwm> pwm = root.cast<volatile SonataPwm>();
+  pwm.address()                             = PWM_ADDRESS;
+  pwm.bounds()                              = PWM_BOUNDS * PWM_NUM;
+  return pwm;
 }
 
 [[maybe_unused]] static UartPtr uart_ptr(CapRoot root, uint32_t idx = 0) {


### PR DESCRIPTION
See the commit messages for more detailed explanations. This PR introduces a new `pinmux_pwm_test` which tests that a PWM instance can be muxed, and that the existing PWM loopback testing works only when the pinmux is configured correctly. If running in CI, this test would be sufficient to catch the issue fixed in #369.

I've tested this on both FPGA and in simulation locally, and the FPGA in CI is already set up with a jumper cable so this test should be passing. I've also added the loopback to the simulation model so this can pass there as well.