### PR TITLE
Added notes on using the RPi header for GPIO.

### DIFF
--- a/doc/ip/gpio.md
+++ b/doc/ip/gpio.md
@@ -72,6 +72,8 @@ The input and output registers have the same bit mapping.
 
 When the output enable is set to zero it instead acts as an input pin.
 
+Note: Before using the Raspberry Pi HAT header's GPIO you should use the pinmux to configure them as input or output.
+
 ## Arduino Shield
 
 The Arduino Shield header has 14 pins that can act as GPIO.

--- a/doc/ip/pinmux/README.md
+++ b/doc/ip/pinmux/README.md
@@ -8,7 +8,7 @@ All selectors are byte addressable, this means that you can write four selectors
 
 There are output pin selectors, which select which block output is connected to a particular FPGA pin.
 The selector is one-hot, so you need to write `8'b100` if you want to select input 3 for example.
-The default value for all of these selectors is `'b10`.
+The default value for all of these selectors is `'b10`. As a consequence, you will need to use the pinmux before attempting use the additional headers as GPIO (e.g. the Raspberry Pi header's GPIO).
 
 | Address | Pin output | Possible block outputs |
 |---------|------------|------------------------|


### PR DESCRIPTION
Added notes to pinmux and GPIO sections of the manual regarding the impact of the pinmux output selector defaulting on 0b10 and the importance of correctly setting the pinmux before attempting to use the RPi header's GPIO pins as outputs.