### PR TITLE
xbar: debug host access to hyperram, system_info

### DIFF
--- a/data/xbar_main.hjson
+++ b/data/xbar_main.hjson
@@ -231,6 +231,10 @@
       "usbdev",
       "rv_plic",
     ],
-    dbg_host: ["sram"],
+    dbg_host: [
+      "sram",
+      "hyperram",
+      "system_info",
+    ],
   },
 }

--- a/data/xbar_main_generated.hjson
+++ b/data/xbar_main_generated.hjson
@@ -322,6 +322,10 @@
       "usbdev",
       "rv_plic",
     ],
-    dbg_host: ["sram"],
+    dbg_host: [
+      "sram",
+      "hyperram",
+      "system_info",
+    ],
   },
 }

--- a/rtl/bus/xbar_main.sv
+++ b/rtl/bus/xbar_main.sv
@@ -10,11 +10,13 @@
 //   -> s1n_25
 //     -> sm1_26
 //       -> sram
-//     -> hyperram
+//     -> sm1_27
+//       -> hyperram
 //     -> rev_tag
 //     -> gpio
 //     -> pinmux
-//     -> system_info
+//     -> sm1_28
+//       -> system_info
 //     -> rgbled_ctrl
 //     -> hw_rev
 //     -> xadc
@@ -30,12 +32,17 @@
 //     -> spi0
 //     -> spi1
 //     -> spi2
-//     -> asf_27
+//     -> asf_29
 //       -> usbdev
 //     -> rv_plic
 // dbg_host
-//   -> sm1_26
-//     -> sram
+//   -> s1n_30
+//     -> sm1_26
+//       -> sram
+//     -> sm1_27
+//       -> hyperram
+//     -> sm1_28
+//       -> system_info
 
 module xbar_main (
   input clk_sys_i,
@@ -125,18 +132,42 @@ module xbar_main (
   tl_h2d_t tl_sm1_26_ds_h2d ;
   tl_d2h_t tl_sm1_26_ds_d2h ;
 
-  tl_h2d_t tl_asf_27_us_h2d ;
-  tl_d2h_t tl_asf_27_us_d2h ;
-  tl_h2d_t tl_asf_27_ds_h2d ;
-  tl_d2h_t tl_asf_27_ds_d2h ;
+
+  tl_h2d_t tl_sm1_27_us_h2d [2];
+  tl_d2h_t tl_sm1_27_us_d2h [2];
+
+  tl_h2d_t tl_sm1_27_ds_h2d ;
+  tl_d2h_t tl_sm1_27_ds_d2h ;
+
+
+  tl_h2d_t tl_sm1_28_us_h2d [2];
+  tl_d2h_t tl_sm1_28_us_d2h [2];
+
+  tl_h2d_t tl_sm1_28_ds_h2d ;
+  tl_d2h_t tl_sm1_28_ds_d2h ;
+
+  tl_h2d_t tl_asf_29_us_h2d ;
+  tl_d2h_t tl_asf_29_us_d2h ;
+  tl_h2d_t tl_asf_29_ds_h2d ;
+  tl_d2h_t tl_asf_29_ds_d2h ;
+
+  tl_h2d_t tl_s1n_30_us_h2d ;
+  tl_d2h_t tl_s1n_30_us_d2h ;
+
+
+  tl_h2d_t tl_s1n_30_ds_h2d [3];
+  tl_d2h_t tl_s1n_30_ds_d2h [3];
+
+  // Create steering signal
+  logic [1:0] dev_sel_s1n_30;
 
 
 
   assign tl_sm1_26_us_h2d[0] = tl_s1n_25_ds_h2d[0];
   assign tl_s1n_25_ds_d2h[0] = tl_sm1_26_us_d2h[0];
 
-  assign tl_hyperram_o = tl_s1n_25_ds_h2d[1];
-  assign tl_s1n_25_ds_d2h[1] = tl_hyperram_i;
+  assign tl_sm1_27_us_h2d[0] = tl_s1n_25_ds_h2d[1];
+  assign tl_s1n_25_ds_d2h[1] = tl_sm1_27_us_d2h[0];
 
   assign tl_rev_tag_o = tl_s1n_25_ds_h2d[2];
   assign tl_s1n_25_ds_d2h[2] = tl_rev_tag_i;
@@ -147,8 +178,8 @@ module xbar_main (
   assign tl_pinmux_o = tl_s1n_25_ds_h2d[4];
   assign tl_s1n_25_ds_d2h[4] = tl_pinmux_i;
 
-  assign tl_system_info_o = tl_s1n_25_ds_h2d[5];
-  assign tl_s1n_25_ds_d2h[5] = tl_system_info_i;
+  assign tl_sm1_28_us_h2d[0] = tl_s1n_25_ds_h2d[5];
+  assign tl_s1n_25_ds_d2h[5] = tl_sm1_28_us_d2h[0];
 
   assign tl_rgbled_ctrl_o = tl_s1n_25_ds_h2d[6];
   assign tl_s1n_25_ds_d2h[6] = tl_rgbled_ctrl_i;
@@ -195,14 +226,20 @@ module xbar_main (
   assign tl_spi2_o = tl_s1n_25_ds_h2d[20];
   assign tl_s1n_25_ds_d2h[20] = tl_spi2_i;
 
-  assign tl_asf_27_us_h2d = tl_s1n_25_ds_h2d[21];
-  assign tl_s1n_25_ds_d2h[21] = tl_asf_27_us_d2h;
+  assign tl_asf_29_us_h2d = tl_s1n_25_ds_h2d[21];
+  assign tl_s1n_25_ds_d2h[21] = tl_asf_29_us_d2h;
 
   assign tl_rv_plic_o = tl_s1n_25_ds_h2d[22];
   assign tl_s1n_25_ds_d2h[22] = tl_rv_plic_i;
 
-  assign tl_sm1_26_us_h2d[1] = tl_dbg_host_i;
-  assign tl_dbg_host_o = tl_sm1_26_us_d2h[1];
+  assign tl_sm1_26_us_h2d[1] = tl_s1n_30_ds_h2d[0];
+  assign tl_s1n_30_ds_d2h[0] = tl_sm1_26_us_d2h[1];
+
+  assign tl_sm1_27_us_h2d[1] = tl_s1n_30_ds_h2d[1];
+  assign tl_s1n_30_ds_d2h[1] = tl_sm1_27_us_d2h[1];
+
+  assign tl_sm1_28_us_h2d[1] = tl_s1n_30_ds_h2d[2];
+  assign tl_s1n_30_ds_d2h[2] = tl_sm1_28_us_d2h[1];
 
   assign tl_s1n_25_us_h2d = tl_ibex_lsu_i;
   assign tl_ibex_lsu_o = tl_s1n_25_us_d2h;
@@ -210,8 +247,17 @@ module xbar_main (
   assign tl_sram_o = tl_sm1_26_ds_h2d;
   assign tl_sm1_26_ds_d2h = tl_sram_i;
 
-  assign tl_usbdev_o = tl_asf_27_ds_h2d;
-  assign tl_asf_27_ds_d2h = tl_usbdev_i;
+  assign tl_hyperram_o = tl_sm1_27_ds_h2d;
+  assign tl_sm1_27_ds_d2h = tl_hyperram_i;
+
+  assign tl_system_info_o = tl_sm1_28_ds_h2d;
+  assign tl_sm1_28_ds_d2h = tl_system_info_i;
+
+  assign tl_usbdev_o = tl_asf_29_ds_h2d;
+  assign tl_asf_29_ds_d2h = tl_usbdev_i;
+
+  assign tl_s1n_30_us_h2d = tl_dbg_host_i;
+  assign tl_dbg_host_o = tl_s1n_30_us_d2h;
 
   always_comb begin
     // default steering to generate error response if address is not within the range
@@ -310,6 +356,23 @@ module xbar_main (
 end
   end
 
+  always_comb begin
+    // default steering to generate error response if address is not within the range
+    dev_sel_s1n_30 = 2'd3;
+    if ((tl_s1n_30_us_h2d.a_address &
+         ~(ADDR_MASK_SRAM)) == ADDR_SPACE_SRAM) begin
+      dev_sel_s1n_30 = 2'd0;
+
+    end else if ((tl_s1n_30_us_h2d.a_address &
+                  ~(ADDR_MASK_HYPERRAM)) == ADDR_SPACE_HYPERRAM) begin
+      dev_sel_s1n_30 = 2'd1;
+
+    end else if ((tl_s1n_30_us_h2d.a_address &
+                  ~(ADDR_MASK_SYSTEM_INFO)) == ADDR_SPACE_SYSTEM_INFO) begin
+      dev_sel_s1n_30 = 2'd2;
+end
+  end
+
 
   // Instantiation phase
   tlul_socket_1n #(
@@ -330,9 +393,8 @@ end
     .dev_select_i (dev_sel_s1n_25)
   );
   tlul_socket_m1 #(
-    .HReqPass  (2'h1),
-    .HReqDepth (8'h10),
-    .HRspDepth (8'h10),
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
     .DReqDepth (4'h0),
     .DRspDepth (4'h0),
     .M         (2)
@@ -344,18 +406,61 @@ end
     .tl_d_o       (tl_sm1_26_ds_h2d),
     .tl_d_i       (tl_sm1_26_ds_d2h)
   );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqDepth (4'h0),
+    .DRspDepth (4'h0),
+    .M         (2)
+  ) u_sm1_27 (
+    .clk_i        (clk_sys_i),
+    .rst_ni       (rst_sys_ni),
+    .tl_h_i       (tl_sm1_27_us_h2d),
+    .tl_h_o       (tl_sm1_27_us_d2h),
+    .tl_d_o       (tl_sm1_27_ds_h2d),
+    .tl_d_i       (tl_sm1_27_ds_d2h)
+  );
+  tlul_socket_m1 #(
+    .HReqDepth (8'h0),
+    .HRspDepth (8'h0),
+    .DReqDepth (4'h0),
+    .DRspDepth (4'h0),
+    .M         (2)
+  ) u_sm1_28 (
+    .clk_i        (clk_sys_i),
+    .rst_ni       (rst_sys_ni),
+    .tl_h_i       (tl_sm1_28_us_h2d),
+    .tl_h_o       (tl_sm1_28_us_d2h),
+    .tl_d_o       (tl_sm1_28_ds_h2d),
+    .tl_d_i       (tl_sm1_28_ds_d2h)
+  );
   tlul_fifo_async #(
     .ReqDepth        (1),
     .RspDepth        (1)
-  ) u_asf_27 (
+  ) u_asf_29 (
     .clk_h_i      (clk_sys_i),
     .rst_h_ni     (rst_sys_ni),
     .clk_d_i      (clk_usb_i),
     .rst_d_ni     (rst_usb_ni),
-    .tl_h_i       (tl_asf_27_us_h2d),
-    .tl_h_o       (tl_asf_27_us_d2h),
-    .tl_d_o       (tl_asf_27_ds_h2d),
-    .tl_d_i       (tl_asf_27_ds_d2h)
+    .tl_h_i       (tl_asf_29_us_h2d),
+    .tl_h_o       (tl_asf_29_us_d2h),
+    .tl_d_o       (tl_asf_29_ds_h2d),
+    .tl_d_i       (tl_asf_29_ds_d2h)
+  );
+  tlul_socket_1n #(
+    .HReqPass  (1'b0),
+    .HRspPass  (1'b0),
+    .DReqDepth (12'h0),
+    .DRspDepth (12'h0),
+    .N         (3)
+  ) u_s1n_30 (
+    .clk_i        (clk_sys_i),
+    .rst_ni       (rst_sys_ni),
+    .tl_h_i       (tl_s1n_30_us_h2d),
+    .tl_h_o       (tl_s1n_30_us_d2h),
+    .tl_d_o       (tl_s1n_30_ds_h2d),
+    .tl_d_i       (tl_s1n_30_ds_d2h),
+    .dev_select_i (dev_sel_s1n_30)
   );
 
 endmodule


### PR DESCRIPTION
With the RTOS mainline gaining some support for code in HyperRAM, it would be nice to be able to load such images in over OpenOCD without needing to write code to do bounce buffering.

While here, also give the debug host access to the system_info peripheral, to provide some more diagnostic information.

Should resolve #381, I think?