### PR TITLE
Move `[[noreturn]]` to after `extern "C"`

### DIFF
--- a/sw/cheri/checks/hyperram_test.cc
+++ b/sw/cheri/checks/hyperram_test.cc
@@ -232,7 +232,7 @@ int execute_test(Capability<volatile uint32_t> &hyperram_area, ds::xoroshiro::P6
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
  */
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   // Create a bounded capability to the UART

--- a/sw/cheri/checks/lcd_check.cc
+++ b/sw/cheri/checks/lcd_check.cc
@@ -154,7 +154,7 @@ static void run_script(Capability<volatile OpenTitanUart> &uart, Capability<vola
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
  */
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   // Create a bounded capability to the UART

--- a/sw/cheri/checks/pinmux_all_blocks_check.cc
+++ b/sw/cheri/checks/pinmux_all_blocks_check.cc
@@ -22,7 +22,7 @@ using namespace CHERI;
  * extreme scenario that all muxed blocks are actually being muxed over the
  * same pins.
  */
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   // Initialise capabilities for UART0 (the console), and all other UARTS (1-4)

--- a/sw/cheri/checks/pinmux_check.cc
+++ b/sw/cheri/checks/pinmux_check.cc
@@ -31,7 +31,7 @@ void block_until_uart_tx_done(Capability<volatile OpenTitanUart> uart) {
  * Then logs again. Then re-enables the connection, and logs one more time.
  * If pinmux is working, then you should not see the middle message.
  */
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   UartPtr uart = uart_ptr(root);

--- a/sw/cheri/checks/pinmux_checker.hh
+++ b/sw/cheri/checks/pinmux_checker.hh
@@ -126,4 +126,4 @@ struct Test {
 };
 
 bool execute_testplan(Test *testplan, uint8_t NumTests, Log &log, ds::xoroshiro::P32R8 &prng, SonataGpioFull *gpio,
-                      UartPtr uarts[4], SpiPtr spis[3], I2cPtr i2cs[2], PinmuxPtrs pinmux);
+                      UartPtr uarts[2], SpiPtr spis[3], I2cPtr i2cs[2], PinmuxPtrs pinmux);

--- a/sw/cheri/checks/revocation_test.cc
+++ b/sw/cheri/checks/revocation_test.cc
@@ -23,7 +23,7 @@ using namespace CHERI;
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
  */
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   // Create a bounded capability to the UART

--- a/sw/cheri/checks/rgbled_test.cc
+++ b/sw/cheri/checks/rgbled_test.cc
@@ -56,7 +56,7 @@ void busy_wait(uint64_t cycles) {
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
  */
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   Capability<volatile SonataRGBLEDCtrl> rgbled_ctrl = root.cast<volatile SonataRGBLEDCtrl>();

--- a/sw/cheri/checks/rs485_check.cc
+++ b/sw/cheri/checks/rs485_check.cc
@@ -19,7 +19,7 @@
 
 using namespace CHERI;
 
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   pin_sinks_ptr(root)->get(SonataPinmux::PinSink::rs485_tx).select(1);

--- a/sw/cheri/checks/rs485_spam_check.cc
+++ b/sw/cheri/checks/rs485_spam_check.cc
@@ -20,7 +20,7 @@
 using namespace CHERI;
 
 // Continuosly outputs a message with an incrementing number on RS485 serial
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   pin_sinks_ptr(root)->get(SonataPinmux::PinSink::rs485_tx).select(1);

--- a/sw/cheri/checks/sdraw_check.cc
+++ b/sw/cheri/checks/sdraw_check.cc
@@ -51,7 +51,7 @@ static int compare_bytes(const uint8_t *ref, const uint8_t *data, size_t len, Lo
   return mismatches;
 }
 
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   CapRoot root{rwRoot};
 
   auto uart0 = uart_ptr(root);

--- a/sw/cheri/checks/spi_test.cc
+++ b/sw/cheri/checks/spi_test.cc
@@ -25,7 +25,7 @@ using namespace CHERI;
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
  */
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   Capability<void> root{rwRoot};
 
   uint8_t write_data[256];

--- a/sw/cheri/checks/system_info_check.cc
+++ b/sw/cheri/checks/system_info_check.cc
@@ -23,7 +23,7 @@ using namespace CHERI;
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
  */
-[[noreturn]] extern "C" void entry_point(void* rwRoot) {
+extern "C" [[noreturn]] void entry_point(void* rwRoot) {
   Capability<void> root{rwRoot};
 
   // Create a bounded capability to the UART.

--- a/sw/cheri/checks/uart_check.cc
+++ b/sw/cheri/checks/uart_check.cc
@@ -23,7 +23,7 @@ using namespace CHERI;
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
  */
-[[noreturn]] extern "C" void entry_point(void* rwRoot) {
+extern "C" [[noreturn]] void entry_point(void* rwRoot) {
   Capability<void> root{rwRoot};
 
   // Create a bounded capability to the UART

--- a/sw/cheri/checks/uart_simexit_check.cc
+++ b/sw/cheri/checks/uart_simexit_check.cc
@@ -23,7 +23,7 @@ using namespace CHERI;
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
  */
-[[noreturn]] extern "C" void entry_point(void* rwRoot) {
+extern "C" [[noreturn]] void entry_point(void* rwRoot) {
   Capability<void> root{rwRoot};
 
   // Create a bounded capability to the UART

--- a/sw/cheri/checks/usbdev_check.cc
+++ b/sw/cheri/checks/usbdev_check.cc
@@ -65,7 +65,7 @@ static void rxCallback(void *rxHandle, uint8_t ep, bool setup, const uint8_t *da
   write_strn(*uart, reinterpret_cast<const char *>(data), pktLen);
 }
 
-[[noreturn]] extern "C" void entry_point(void *rwRoot) {
+extern "C" [[noreturn]] void entry_point(void *rwRoot) {
   // Buffer for data transfer to/from the USB device.
   //  uint8_t _Alignas(uint32_t) data[OpenTitanUsbdev::MaxPacketLength];
 


### PR DESCRIPTION
Move the `[[noreturn]]` attribute to after `extern "C"` when both are used on the one line.
This seems to be required by LLVM 18.