### PR TITLE
PLIC: Remove integrity countermeasure for generate

### DIFF
--- a/rtl/system/autogen/rv_plic/data/rv_plic.hjson
+++ b/rtl/system/autogen/rv_plic/data/rv_plic.hjson
@@ -97,12 +97,6 @@
     },
   ]
 
-  countermeasures: [
-    { name: "BUS.INTEGRITY",
-      desc: "End-to-end bus integrity scheme."
-    }
-  ]
-
   features: [
     { name: "RV_PLIC.PRIORITY",
       desc: '''Each interrupt source can be given a configurable priority.'''

--- a/util/top_gen/generator.py
+++ b/util/top_gen/generator.py
@@ -368,5 +368,7 @@ def generate_top(config: TopConfig) -> None:
             ["clang-format", "sw/cheri/common/platform-pinmux.hh", "-i"],
             check=True,
         )
+        subprocess.run(["sh", "util/generate_plic.sh"], check=True)
+        subprocess.run(["bash", "util/reg_gen.sh"], check=True)
     except subprocess.CalledProcessError as err:
         exit(err.returncode)

--- a/vendor/lowrisc_ip/ip_templates/rv_plic/data/rv_plic.hjson.tpl
+++ b/vendor/lowrisc_ip/ip_templates/rv_plic/data/rv_plic.hjson.tpl
@@ -98,12 +98,6 @@
     },
   ]
 
-  countermeasures: [
-    { name: "BUS.INTEGRITY",
-      desc: "End-to-end bus integrity scheme."
-    }
-  ]
-
   features: [
     { name: "RV_PLIC.PRIORITY",
       desc: '''Each interrupt source can be given a configurable priority.'''

--- a/vendor/patches/lowrisc_ip/rv_plic/0002-Integrity-Countermeasure-Removed.patch
+++ b/vendor/patches/lowrisc_ip/rv_plic/0002-Integrity-Countermeasure-Removed.patch
@@ -1,0 +1,17 @@
+diff --git a/data/rv_plic.hjson.tpl b/data/rv_plic.hjson.tpl
+index 23c12048..e4f6948c 100644
+--- a/data/rv_plic.hjson.tpl
++++ b/data/rv_plic.hjson.tpl
+@@ -98,12 +98,6 @@
+     },
+   ]
+ 
+-  countermeasures: [
+-    { name: "BUS.INTEGRITY",
+-      desc: "End-to-end bus integrity scheme."
+-    }
+-  ]
+-
+   features: [
+     { name: "RV_PLIC.PRIORITY",
+       desc: '''Each interrupt source can be given a configurable priority.'''


### PR DESCRIPTION
Previously util/generate_plic.sh would generate an error because the integrity countermeasure was not implemented in the RTL. This removes that countermeasure from the template.