### PR TITLE
Boot stub must end with 4-byte alignment

### DIFF
--- a/sw/cheri/sim_boot_stub/boot.S
+++ b/sw/cheri/sim_boot_stub/boot.S
@@ -18,3 +18,10 @@ start:
   li               t0, HYPERRAM_BASE
   csetaddr         ct1, ct1, t0
   cjr              ct1
+
+// Make sure the file ends with a 4-byte aligned region.
+  .globl end
+  .p2align 2
+end:
+  nop
+  nop

--- a/sw/cheri/sim_boot_stub/boot_sram.S
+++ b/sw/cheri/sim_boot_stub/boot_sram.S
@@ -18,3 +18,10 @@ start:
   li               t0, SRAM_BASE
   csetaddr         ct1, ct1, t0
   cjr              ct1
+
+// Make sure the file ends with a 4-byte aligned region.
+  .globl end
+  .p2align 2
+end:
+  nop
+  nop


### PR DESCRIPTION
This allows it to be written out over the debug module interface.