### PR TITLE
Add Pin-Change Interrupts (PCINT) to GPIO

### DIFF
--- a/doc/ip/gpio.md
+++ b/doc/ip/gpio.md
@@ -1,43 +1,126 @@
 # GPIO
 
-General purpose input and output is used for Ibex to interact with the buttons and switches on the board.
-It is also used to drive the LEDs on the board.
-There are also the GPIO pins of the various headers.
+The General Purpose Input and Output (GPIO) sub-system provides a generic low-speed means of interacting with components outside of the FPGA.
+Multiple GPIO instances are provided in an array within the GPIO sub-system.
+The first GPIO instance allows Ibex to sense the state of the on-board buttons/switches and to drive the on-board LEDs.
+Further GPIO instances are provided for the GPIO pins of the various on-board expansion headers.
+Pin-Change INTerrupt (PCINT) logic allows interrupts to be generated from external stimuli.
 
-For the input this module provides a raw value as well as a debounced value.
-Debouncing is useful to avoid counting a single button press multiple times.
-For more information on contact bounce, see [this Wikipedia page](https://en.wikipedia.org/wiki/Switch#Contact_bounce).
+Note that the PCINT capture logic is not asynchronous.
+A pin must change for at least one system-clock cycle (default 40 MHz) to be detected.
+
+## Registers
+
+Each instance has its own self-contained set of registers to aid compartmentalisation.
+
+Most of the registers within most instances share an instance-specific mapping between register bits and external pins.
+The common case is where the same pins are used for both input or output, and for register bits to each represent pins.
+The exceptions are the on-board peripherals GPIO *instance*, and the control and status *registers*.
+Both of these kinds of special case are covered further below.
+
+### Output & Output Enable Registers
+
+Pins can be driven as outputs by setting matching bits in the output enable register and writing the desired value to the output register.
+When writing, it only writes the bits for which the output is set to enable.
+When the output enable is set to zero it instead acts as an input pin.
+
+The input and output registers have the same bit mapping for all but the on-board peripherals GPIO instance.
+
+### Input & Debounced Input Registers
+
+Each GPIO instance provides debounced input values as well as raw (pre-debouncing) values in separate registers.
+Debouncing is useful when using mechanical switches to avoid counting a single button press multiple times.
+For more information on why this is, see [the Wikipedia page on contact bounce](https://en.wikipedia.org/wiki/Switch#Contact_bounce).
+Debouncing is performed by checking that any change on an input pin remains stable throughout at least one cycle of a shared hardware timer before the change is propagated to the register.
+The alternative 'raw' input register is provided for situations where more precise timing is required.
+
+### Control & Status Registers
+
+The control register and the status register are the only registers where each bit is not mapped to a physical pin.
+
+The control register is currently only used for PCINT functionality.
+
+| Bit offset | Description |
+|------------|-------------|
+| 31         | PCINT instance-wide enable; does not affect the operation of the status register. |
+| 30-4       | Reserved |
+| 3          | PCINT debounced input select: 0=raw-input, 1=debounced-input. |
+| 2          | Reserved |
+| 1-0        | PCINT mode: 0=any-edge, 1=rising-edge, 2=falling-edge, 3=low-level. |
+
+The status register is currently only used for PCINT functionality.
+
+| Bit offset | Description |
+|------------|-------------|
+| 31         | PCINT status; write `1` to clear. |
+
+### PCINT Mask Register
+
+The PCINT mask register allows a custom subset of pins to be used for PCINT generation.
+Set a bit to enable monitoring and possible PCINT generation according to the state of the control and status register.
+Clear a bit to ignore that pin.
+
+The input and PCINT mask registers have the same bit mapping for all GPIO instances.
+
+## Memory Map
+
+The addresses of each register of each GPIO instance is given in the following table.
 
 | Offset | Register                 |
 |--------|--------------------------|
-| 0x0000 | Output                   |
-| 0x0004 | Input                    |
-| 0x0008 | Debounced input          |
-| 0x000C | Output enable (currently not used) |
+| 0x0000 | On-board output          |
+| 0x0004 | On-board input           |
+| 0x0008 | On-board debounced input |
+| 0x000C | On-board output enable (currently not used) |
+| 0x0010 | On-board control         |
+| 0x0014 | On-board status          |
+| 0x0018 | On-board PCINT mask      |
 | 0x0040 | R-Pi output              |
 | 0x0044 | R-Pi input               |
 | 0x0048 | R-pi debounced input     |
 | 0x004C | R-pi output enable       |
+| 0x0050 | R-Pi control            |
+| 0x0054 | R-Pi status              |
+| 0x0058 | R-Pi PCINT mask          |
 | 0x0080 | Arduino output           |
 | 0x0084 | Arduino input            |
 | 0x0088 | Arduino debounced input  |
 | 0x008C | Arduino output enable    |
+| 0x0090 | Arduino Control |
+| 0x0094 | Arduino status           |
+| 0x0098 | Arduino PCINT mask       |
 | 0x00C0 | PMOD0 output             |
 | 0x00C4 | PMOD0 input              |
 | 0x00C8 | PMOD0 debounced input    |
 | 0x00CC | PMOD0 output enable      |
+| 0x00D0 | PMOD0 control            |
+| 0x00D4 | PMOD0 status             |
+| 0x00D8 | PMOD0 PCINT mask         |
 | 0x0100 | PMOD1 output             |
 | 0x0104 | PMOD1 input              |
 | 0x0108 | PMOD1 debounced input    |
 | 0x010C | PMOD1 output enable      |
+| 0x0110 | PMOD1 control            |
+| 0x0114 | PMOD1 status             |
+| 0x0118 | PMOD1 PCINT mask         |
 | 0x0140 | PMODC output             |
 | 0x0144 | PMODC input              |
 | 0x0148 | PMODC debounced input    |
 | 0x014C | PMODC output enable      |
+| 0x0150 | PMODC control            |
+| 0x0154 | PMODC status             |
+| 0x0158 | PMODC PCINT mask         |
 
-## Output
+## Instances
 
-The output register displays the specified value onto the boards output.
+There are several GPIO instances, each with its own mapping of external pins to register bits.
+
+### On-board Peripherals
+
+Unlike most GPIO instances here, the on-board peripherals instance uses a different pin mapping for input compared to output.
+It interfaces with soldered-on user switches, buttons, and LEDs, for each of which only one of input or output makes sense.
+
+The output register drives the user LEDs.
 
 | Bit offset | Description |
 |------------|-------------|
@@ -45,10 +128,9 @@ The output register displays the specified value onto the boards output.
 
 In this case writing a one will turn an LED on and a zero will turn the LED off.
 
-## Input
+Note: the output enable register does nothing in this instance, as the outputs are not shared with inputs.
 
-Both input registers have the same bit mapping.
-The only difference between the registers is that the latter has debounced signals.
+The raw input and debounced input registers sense the state of the various user switches/buttons/joystick available on the board, and the microSD card detection line.
 
 | Bit offset | Description |
 |------------|-------------|
@@ -57,45 +139,33 @@ The only difference between the registers is that the latter has debounced signa
 | 12-8       | Joystick (left, down, up, right, press) |
 | 7-0        | DIP switches |
 
-The input registers are used to interact with the joystick, the button and the DIP switches that are available on the Sonata board.
+It is recommended to use the debounced input for these mechanical switches.
 
-## Raspberry Pi HAT
+### Raspberry Pi HAT
 
 The Raspberry Pi HAT header has 28 pins that can act as GPIO.
-Some can be remapped to other IP blocks (see Pinmux).
-When writing, it only writes the bits for which the output is set to enable.
-The input and output registers have the same bit mapping.
+Some can be remapped to other IP blocks (see Pinmux documentation).
 
 | Bit offset | Description  |
 |------------|--------------|
 | 27-0       | GPIO 27 to 0 |
 
-When the output enable is set to zero it instead acts as an input pin.
-
 Note: Before using the Raspberry Pi HAT header's GPIO you should use the pinmux to configure them as input or output.
 
-## Arduino Shield
+### Arduino Shield
 
 The Arduino Shield header has 14 pins that can act as GPIO.
-When writing, it only writes the bits for which the output is set to enable.
-The input and output registers have the same bit mapping.
 
 | Bit offset | Description  |
 |------------|--------------|
 | 13-0       | GPIO 13 to 0 |
 
-When the output enable is set to zero it instead acts as an input pin.
-
-## Pmod
+### Pmod
 
 The Pmod header is split up as Pmod 0, C and 1.
 Pmod 0 and 1 have 8 GPIO outputs each while C has 6.
-When writing, it only writes the bits for which the output is set to enable.
-The input and output registers have the same bit mapping.
 
 | Bit offset | Description |
 |------------|-------------|
 | 7-6        | Accessible for Pmod 0 and 1 only |
 | 5-0        | Accessible for Pmod 0, 1 and C |
-
-When the output enable is set to zero it instead acts as an input pin.

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -279,21 +279,23 @@ module top_verilator (input logic clk_i, rst_ni);
   // these signals are re-timed through a single register stage simply to prevent Verilator
   // warnings about circular combinational logic which assesses circularity at the net level
   // (i.e. `in_from_pins` and `out_to_pins`) rather than the bit level.
-  reg [5:0] loopback_q;
+  reg [6:0] loopback_q;
   always @(posedge clk_i) begin
     loopback_q <= {inout_to_pins[INOUT_PIN_AH_TMPIO8],
                    inout_to_pins[INOUT_PIN_AH_TMPIO1],
                    out_to_pins[OUT_PIN_MB10],  // mikroBUS CLick PWM -> PMOD0.1; PWM loopback
                    out_to_pins[OUT_PIN_MB7],   // mikroBUS Click TX -> RX; UART loopback.
                    out_to_pins[OUT_PIN_MB4],  // mikroBUS Click COPI -> CIPO; SPI loopback.
-                   inout_to_pins[INOUT_PIN_PMOD0_8]}; // PMOD0 8->10; PWM loopback
+                   inout_to_pins[INOUT_PIN_PMOD0_8], // PMOD0 8->10; PWM loopback
+                   inout_to_pins[INOUT_PIN_PMODC_1]}; // PMODC 1->1; GPIO PCINT 'loopback'
   end
   assign {inout_from_pins[INOUT_PIN_AH_TMPIO9],
           inout_from_pins[INOUT_PIN_AH_TMPIO0],
           inout_from_pins[INOUT_PIN_PMOD0_1],
           in_from_pins[IN_PIN_MB8],
           in_from_pins[IN_PIN_MB3],
-          inout_from_pins[INOUT_PIN_PMOD0_10]} = loopback_q;
+          inout_from_pins[INOUT_PIN_PMOD0_10],
+          inout_from_pins[INOUT_PIN_PMODC_1]} = loopback_q;
 
   // JTAG signals
   wire jtag_tck;

--- a/rtl/ip/gpio/gpio.core
+++ b/rtl/ip/gpio/gpio.core
@@ -14,6 +14,7 @@ filesets:
       - rtl/gpio_core.sv
       - rtl/gpio_array.sv
       - rtl/gpio.sv
+      - rtl/pcint.sv
     file_type: systemVerilogSource
 
 targets:

--- a/rtl/ip/gpio/rtl/gpio.sv
+++ b/rtl/ip/gpio/rtl/gpio.sv
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module gpio #(
-  parameter int unsigned GpiWidth     =  8,
-  parameter int unsigned GpoWidth     = 16,
+  parameter int unsigned GpiMaxWidth  =  8,
+  parameter int unsigned GpoMaxWidth  = 16,
   parameter int unsigned AddrWidth    = 32,
   parameter int unsigned DataWidth    = 32,
   parameter int unsigned RegAddrWidth = 12,
-  parameter int unsigned NumInstances =  1
+  parameter int unsigned NumInstances =  1,
+  parameter int unsigned GpiInstWidths[NumInstances] =  {8},
+  parameter int unsigned GpoInstWidths[NumInstances] = {16}
 ) (
   input  logic clk_i,
   input  logic rst_ni,
@@ -16,11 +18,11 @@ module gpio #(
   input  tlul_pkg::tl_h2d_t tl_i,
   output tlul_pkg::tl_d2h_t tl_o,
 
-  input  logic [GpiWidth-1:0] gp_i[NumInstances],
-  output logic [GpoWidth-1:0] gp_o[NumInstances],
-  output logic [GpoWidth-1:0] gp_o_en[NumInstances],
+  input  logic [GpiMaxWidth-1:0] gp_i[NumInstances],
+  output logic [GpoMaxWidth-1:0] gp_o[NumInstances],
+  output logic [GpoMaxWidth-1:0] gp_o_en[NumInstances],
 
-  output logic                pcint_o[NumInstances]
+  output logic                   pcint_o[NumInstances]
 );
 
   logic                 device_req;
@@ -37,12 +39,14 @@ module gpio #(
   assign device_addr[AddrWidth-1:RegAddrWidth] = '0;
 
   gpio_array #(
-    .GpiWidth     ( GpiWidth     ),
-    .GpoWidth     ( GpoWidth     ),
-    .AddrWidth    ( AddrWidth    ),
-    .DataWidth    ( DataWidth    ),
-    .RegAddrWidth ( RegAddrWidth ),
-    .NumInstances ( NumInstances )
+    .GpiMaxWidth   ( GpiMaxWidth   ),
+    .GpoMaxWidth   ( GpoMaxWidth   ),
+    .AddrWidth     ( AddrWidth     ),
+    .DataWidth     ( DataWidth     ),
+    .RegAddrWidth  ( RegAddrWidth  ),
+    .NumInstances  ( NumInstances  ),
+    .GpiInstWidths ( GpiInstWidths ),
+    .GpoInstWidths ( GpoInstWidths )
   ) u_gpio (
     .clk_i,
     .rst_ni,

--- a/rtl/ip/gpio/rtl/gpio.sv
+++ b/rtl/ip/gpio/rtl/gpio.sv
@@ -18,7 +18,9 @@ module gpio #(
 
   input  logic [GpiWidth-1:0] gp_i[NumInstances],
   output logic [GpoWidth-1:0] gp_o[NumInstances],
-  output logic [GpoWidth-1:0] gp_o_en[NumInstances]
+  output logic [GpoWidth-1:0] gp_o_en[NumInstances],
+
+  output logic                pcint_o[NumInstances]
 );
 
   logic                 device_req;
@@ -55,7 +57,9 @@ module gpio #(
 
     .gp_i,
     .gp_o,
-    .gp_o_en
+    .gp_o_en,
+
+    .pcint_o
   );
 
   tlul_adapter_reg #(

--- a/rtl/ip/gpio/rtl/gpio_array.sv
+++ b/rtl/ip/gpio/rtl/gpio_array.sv
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module gpio_array #(
-  parameter int unsigned GpiWidth     =  8,
-  parameter int unsigned GpoWidth     = 16,
+  parameter int unsigned GpiMaxWidth  =  8,
+  parameter int unsigned GpoMaxWidth  = 16,
   parameter int unsigned AddrWidth    = 32,
   parameter int unsigned DataWidth    = 32,
   parameter int unsigned RegAddrWidth = 12,
-  parameter int unsigned NumInstances =  1
+  parameter int unsigned NumInstances =  1,
+  parameter int unsigned GpiInstWidths[NumInstances] =  {8},
+  parameter int unsigned GpoInstWidths[NumInstances] = {16}
 ) (
   input  logic clk_i,
   input  logic rst_ni,
@@ -21,11 +23,11 @@ module gpio_array #(
   output logic                 device_rvalid_o,
   output logic [DataWidth-1:0] device_rdata_o,
 
-  input  logic [GpiWidth-1:0] gp_i[NumInstances],
-  output logic [GpoWidth-1:0] gp_o[NumInstances],
-  output logic [GpoWidth-1:0] gp_o_en[NumInstances],
+  input  logic [GpiMaxWidth-1:0] gp_i[NumInstances],
+  output logic [GpoMaxWidth-1:0] gp_o[NumInstances],
+  output logic [GpoMaxWidth-1:0] gp_o_en[NumInstances],
 
-  output logic                pcint_o[NumInstances]
+  output logic                   pcint_o[NumInstances]
 );
   localparam int unsigned NumBytesPerInstance = 16 * DataWidth/8;
   localparam int unsigned AddrBitsPerInstance = $clog2(NumBytesPerInstance);
@@ -39,8 +41,8 @@ module gpio_array #(
                              device_req_i : 1'b0;
 
     gpio_core #(
-      .GpiWidth  ( GpiWidth            ),
-      .GpoWidth  ( GpoWidth            ),
+      .GpiWidth  ( GpiInstWidths[i]    ),
+      .GpoWidth  ( GpoInstWidths[i]    ),
       .AddrWidth ( AddrWidth           ),
       .DataWidth ( DataWidth           ),
       .RegAddr   ( AddrBitsPerInstance )
@@ -54,9 +56,9 @@ module gpio_array #(
       .device_wdata_i,
       .device_rvalid_o(device_read_valids[i]),
       .device_rdata_o(device_read_datas[i]),
-      .gp_i(gp_i[i]),
-      .gp_o(gp_o[i]),
-      .gp_o_en(gp_o_en[i]),
+      .gp_i(gp_i[i][GpiInstWidths[i]-1:0]),
+      .gp_o(gp_o[i][GpoInstWidths[i]-1:0]),
+      .gp_o_en(gp_o_en[i][GpoInstWidths[i]-1:0]),
       .pcint_o(pcint_o[i])
     );
   end

--- a/rtl/ip/gpio/rtl/gpio_array.sv
+++ b/rtl/ip/gpio/rtl/gpio_array.sv
@@ -23,7 +23,9 @@ module gpio_array #(
 
   input  logic [GpiWidth-1:0] gp_i[NumInstances],
   output logic [GpoWidth-1:0] gp_o[NumInstances],
-  output logic [GpoWidth-1:0] gp_o_en[NumInstances]
+  output logic [GpoWidth-1:0] gp_o_en[NumInstances],
+
+  output logic                pcint_o[NumInstances]
 );
   localparam int unsigned NumBytesPerInstance = 16 * DataWidth/8;
   localparam int unsigned AddrBitsPerInstance = $clog2(NumBytesPerInstance);
@@ -54,7 +56,8 @@ module gpio_array #(
       .device_rdata_o(device_read_datas[i]),
       .gp_i(gp_i[i]),
       .gp_o(gp_o[i]),
-      .gp_o_en(gp_o_en[i])
+      .gp_o_en(gp_o_en[i]),
+      .pcint_o(pcint_o[i])
     );
   end
 

--- a/rtl/ip/gpio/rtl/gpio_core.sv
+++ b/rtl/ip/gpio/rtl/gpio_core.sv
@@ -7,7 +7,7 @@ module gpio_core #(
   parameter int unsigned GpoWidth  = 16,
   parameter int unsigned AddrWidth = 32,
   parameter int unsigned DataWidth = 32,
-  parameter int unsigned RegAddr   = 12,
+  parameter int unsigned RegAddr   = 6,
   parameter int unsigned DbncWidth = 10
 ) (
   input  logic clk_i,

--- a/rtl/ip/gpio/rtl/gpio_core.sv
+++ b/rtl/ip/gpio/rtl/gpio_core.sv
@@ -23,13 +23,18 @@ module gpio_core #(
 
   input  logic [GpiWidth-1:0] gp_i,
   output logic [GpoWidth-1:0] gp_o,
-  output logic [GpoWidth-1:0] gp_o_en
+  output logic [GpoWidth-1:0] gp_o_en,
+
+  output logic                pcint_o
 );
 
-  localparam int unsigned GPIO_OUT_REG = 32'h0;
-  localparam int unsigned GPIO_IN_REG = 32'h4;
-  localparam int unsigned GPIO_IN_DBNC_REG = 32'h8;
-  localparam int unsigned GPIO_OUT_EN_REG = 32'hC;
+  localparam int unsigned GPIO_OUT_REG      = 32'h00;
+  localparam int unsigned GPIO_IN_REG       = 32'h04;
+  localparam int unsigned GPIO_IN_DBNC_REG  = 32'h08;
+  localparam int unsigned GPIO_OUT_EN_REG   = 32'h0C;
+  localparam int unsigned GPIO_CTRL_REG     = 32'h10;
+  localparam int unsigned GPIO_STATUS_REG   = 32'h14;
+  localparam int unsigned GPIO_PIN_MASK_REG = 32'h18;
 
   logic [RegAddr-1:0] reg_addr;
 
@@ -38,18 +43,29 @@ module gpio_core #(
   logic [GpoWidth-1:0] gp_o_d;
   logic [GpoWidth-1:0] gp_o_en_d;
 
-  logic gp_o_sel, gp_o_rd_en;
-  logic gp_i_sel, gp_i_rd_en;
-  logic gp_i_dbnc_sel, gp_i_dbnc_rd_en;
-  logic gp_o_en_sel, gp_o_en_rd_en;
+  logic gp_o_sel;
+  logic gp_o_en_sel;
+  logic ctrl_sel;
+  logic status_sel;
+  logic pcint_mask_sel;
+
+  logic [RegAddr-3:0] rd_reg_idx;
 
   logic [DbncWidth-1:0] dbnc_cnt;
   logic dbnc_step;
 
+  logic [GpiWidth-1:0] pcint_mask, pcint_mask_d;
+
+  logic pcint_triggered;
+  logic pcint_status, pcint_status_d;
+  logic pcint_enable, pcint_enable_d;
+  logic [1:0] pcint_mode, pcint_mode_d;
+  logic pcint_i_sel, pcint_i_sel_d;
+
   // Shared counter to generate the step-pulses for input debouncers.
   // Prefer to use an extra flop rather than have to AND all the bits
   // together as the wider Sonata system is very logic-heavy.
-  always @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       dbnc_cnt <= '0;
     end else begin
@@ -81,31 +97,55 @@ module gpio_core #(
     );
   end
 
-  always @(posedge clk_i or negedge rst_ni) begin
+  // Instantiated Pin-Change Interrupt (PCINT) unit wide enough for all inputs.
+  pcint #(
+    .Width(GpiWidth)
+  ) u_pcint (
+    .clk_i,
+    .rst_ni,
+    .mode_i(pcint_mode),
+    .i_sel_i(pcint_i_sel),
+    .pin_mask_i(pcint_mask),
+    .sync_i(gp_i_sync),
+    .dbnc_i(gp_i_dbnc),
+    .pcint_o(pcint_triggered)
+  );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      gp_o            <= '0;
-      gp_o_en         <= '0;
-      device_rvalid_o <= '0;
-      gp_o_rd_en      <= '0;
-      gp_i_rd_en      <= '0;
-      gp_i_dbnc_rd_en <= '0;
-      gp_o_en_rd_en   <= '0;
+      gp_o              <= '0;
+      gp_o_en           <= '0;
+      device_rvalid_o   <= '0;
+      pcint_mask        <= '0;
+      pcint_enable      <= '0;
+      pcint_mode        <= '0;
+      pcint_i_sel       <= '0;
+      pcint_status      <= '0;
+      rd_reg_idx        <= '0;
     end else begin
-      if (gp_o_sel & device_we_i) begin
-        gp_o <= gp_o_d;
+      gp_o         <= (gp_o_sel && device_we_i)       ? gp_o_d         : gp_o;
+      gp_o_en      <= (gp_o_en_sel && device_we_i)    ? gp_o_en_d      : gp_o_en;
+      pcint_mask   <= (pcint_mask_sel && device_we_i) ? pcint_mask_d   : pcint_mask;
+      pcint_enable <= (ctrl_sel && device_we_i)       ? pcint_enable_d : pcint_enable;
+      pcint_mode   <= (ctrl_sel && device_we_i)       ? pcint_mode_d   : pcint_mode;
+      pcint_i_sel  <= (ctrl_sel && device_we_i)       ? pcint_i_sel_d  : pcint_i_sel;
+
+      // pcint_status is set by hardware and only cleared when a '1' is written
+      if (pcint_triggered) begin
+        pcint_status <= 1'b1;
+      end else if (status_sel && device_we_i && pcint_status_d) begin
+        pcint_status <= 1'b0;
+      end else begin
+        pcint_status <= pcint_status;
       end
-      if (gp_o_en_sel & device_we_i) begin
-        gp_o_en <= gp_o_en_d;
-      end
-      device_rvalid_o <= device_req_i  & ~device_we_i;
-      gp_o_rd_en      <= gp_o_sel      & ~device_we_i;
-      gp_i_rd_en      <= gp_i_sel      & ~device_we_i;
-      gp_i_dbnc_rd_en <= gp_i_dbnc_sel & ~device_we_i;
-      gp_o_en_rd_en   <= gp_o_en_sel   & ~device_we_i;
+
+      device_rvalid_o <= device_req_i && !device_we_i;
+      rd_reg_idx <= reg_addr[RegAddr-1:2];
     end
   end
 
-  logic [3:0] unused_device_be;
+  logic [3:0] unused_o_device_be;
+  logic [3:0] unused_i_device_be;
 
   // Assign gp_o_d regarding to device_be_i and GpoWidth.
   for (genvar i_byte = 0; i_byte < 4; ++i_byte) begin : g_gp_o_d;
@@ -117,32 +157,61 @@ module gpio_core #(
       assign gp_o_en_d[gpo_byte_end - 1 : i_byte * 8] =
         device_be_i[i_byte] ? device_wdata_i[gpo_byte_end - 1 : i_byte * 8] :
                               gp_o_en[gpo_byte_end - 1 : i_byte * 8];
-      assign unused_device_be[i_byte] = 0;
+      assign unused_o_device_be[i_byte] = 0;
     end else begin : gen_unused_device_be
-      assign unused_device_be[i_byte] = device_be_i[i_byte];
+      assign unused_o_device_be[i_byte] = device_be_i[i_byte];
     end
   end
 
-  // Decode write and read requests.
-  assign reg_addr      = device_addr_i[RegAddr-1:0];
-  assign gp_o_sel      = device_req_i & (reg_addr == GPIO_OUT_REG[RegAddr-1:0]);
-  assign gp_i_sel      = device_req_i & (reg_addr == GPIO_IN_REG[RegAddr-1:0]);
-  assign gp_i_dbnc_sel = device_req_i & (reg_addr == GPIO_IN_DBNC_REG[RegAddr-1:0]);
-  assign gp_o_en_sel   = device_req_i & (reg_addr == GPIO_OUT_EN_REG[RegAddr-1:0]);
+  // Assign pcint_mask_d regarding to device_be_i and GpiWidth.
+  for (genvar i_byte = 0; i_byte < 4; ++i_byte) begin : g_pcint_mask_d;
+    if (i_byte * 8 < GpiWidth) begin : gen_pcint_mask_d_inner
+      localparam int gpi_byte_end = (i_byte + 1) * 8 <= GpiWidth ? (i_byte + 1) * 8 : GpiWidth;
+      assign pcint_mask_d[gpi_byte_end - 1 : i_byte * 8] =
+        device_be_i[i_byte] ? device_wdata_i[gpi_byte_end - 1 : i_byte * 8] :
+                              pcint_mask[gpi_byte_end - 1 : i_byte * 8];
+      assign unused_i_device_be[i_byte] = 0;
+    end else begin : gen_unused_device_be
+      assign unused_i_device_be[i_byte] = device_be_i[i_byte];
+    end
+  end
+
+  assign pcint_status_d = device_be_i[3] ? device_wdata_i[31]  : 1'b0; // special case
+  assign pcint_enable_d = device_be_i[3] ? device_wdata_i[31]  : pcint_enable;
+  assign pcint_i_sel_d  = device_be_i[0] ? device_wdata_i[3]   : pcint_i_sel;
+  assign pcint_mode_d   = device_be_i[0] ? device_wdata_i[1:0] : pcint_mode;
+
+  // Decode write requests.
+  assign reg_addr       = device_addr_i[RegAddr-1:0];
+  assign gp_o_sel       = device_req_i & (reg_addr == GPIO_OUT_REG[RegAddr-1:0]);
+  assign gp_o_en_sel    = device_req_i & (reg_addr == GPIO_OUT_EN_REG[RegAddr-1:0]);
+  assign ctrl_sel       = device_req_i & (reg_addr == GPIO_CTRL_REG[RegAddr-1:0]);
+  assign status_sel     = device_req_i & (reg_addr == GPIO_STATUS_REG[RegAddr-1:0]);
+  assign pcint_mask_sel = device_req_i & (reg_addr == GPIO_PIN_MASK_REG[RegAddr-1:0]);
 
   // Assign device_rdata_o according to request type.
   always_comb begin
-    if (gp_o_rd_en)
+    if (!device_rvalid_o)
+      device_rdata_o = {(DataWidth){1'b0}};
+    else if (rd_reg_idx == GPIO_OUT_REG[RegAddr-1:2])
       device_rdata_o = {{(DataWidth - GpoWidth){1'b0}}, gp_o};
-    else if (gp_i_rd_en)
+    else if (rd_reg_idx == GPIO_IN_REG[RegAddr-1:2])
       device_rdata_o = {{(DataWidth - GpiWidth){1'b0}}, gp_i_sync};
-    else if (gp_i_dbnc_rd_en)
+    else if (rd_reg_idx == GPIO_IN_DBNC_REG[RegAddr-1:2])
       device_rdata_o = {{(DataWidth - GpiWidth){1'b0}}, gp_i_dbnc};
-    else if (gp_o_en_rd_en)
+    else if (rd_reg_idx == GPIO_OUT_EN_REG[RegAddr-1:2])
       device_rdata_o = {{(DataWidth - GpoWidth){1'b0}}, gp_o_en};
+    else if (rd_reg_idx == GPIO_CTRL_REG[RegAddr-1:2])
+      device_rdata_o = {pcint_enable, 27'b0, pcint_i_sel, 1'b0, pcint_mode};
+    else if (rd_reg_idx == GPIO_STATUS_REG[RegAddr-1:2])
+      device_rdata_o = {pcint_status, 31'b0};
+    else if (rd_reg_idx == GPIO_PIN_MASK_REG[RegAddr-1:2])
+      device_rdata_o = {{(DataWidth - GpiWidth){1'b0}}, pcint_mask};
     else
       device_rdata_o = {(DataWidth){1'b0}};
   end
+
+  assign pcint_o = pcint_enable & pcint_status;
 
   // Unused signals.
   if (AddrWidth > RegAddr) begin : g_unused_addr_bits

--- a/rtl/ip/gpio/rtl/pcint.sv
+++ b/rtl/ip/gpio/rtl/pcint.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Derive a Pin-Change Interrupt (PCINT) from a bank of inputs and config.
+// There are four modes: rising-edge, falling-edge, either edge, and low level.
+// Each input pin is evaluated individually and can each be masked.
+// Either synchronised (pre-debounce) or debounced inputs can be used.
+// Only one interrupt output is present, which any unmasked input can trigger.
+// The interrupt will only stay high while the trigger condition remains true,
+// any latching must be done externally.
+
+module pcint #(
+  parameter int unsigned Width = 8
+) (
+  input  logic clk_i,
+  input  logic rst_ni,
+
+  input  logic [1:0]       mode_i,
+  input  logic             i_sel_i,
+  input  logic [Width-1:0] pin_mask_i,
+
+  input  logic [Width-1:0] sync_i,
+  input  logic [Width-1:0] dbnc_i,
+
+  output logic pcint_o
+);
+
+  localparam logic[1:0] PCMODE_EDGE = 2'b00; // rising or falling edges
+  localparam logic[1:0] PCMODE_RISE = 2'b01; // rising edges only
+  localparam logic[1:0] PCMODE_FALL = 2'b10; // falling edges only
+  localparam logic[1:0] PCMODE_LOW  = 2'b11; // low-level (not edge based)
+
+  logic [Width-1:0] prev_in_q;
+  logic pcint_q;
+
+  logic [Width-1:0] curr_in;
+  logic [Width-1:0] rising;
+  logic [Width-1:0] falling;
+  logic [Width-1:0] pn_int;
+
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      prev_in_q <= '0;
+      pcint_q <= '0;
+    end else begin
+      prev_in_q <= curr_in;
+      pcint_q <= (|pn_int); // combined masked pin-specific interrupts
+    end
+  end
+
+  assign curr_in = i_sel_i ? dbnc_i : sync_i;
+
+  assign rising  =   curr_in  & (~prev_in_q);
+  assign falling = (~curr_in) &   prev_in_q;
+
+  for (genvar pn = 0; pn < Width; pn++) begin
+    assign pn_int[pn] = pin_mask_i[pn] && (
+      (mode_i == PCMODE_LOW && !curr_in[pn]) ||
+      ((mode_i == PCMODE_RISE || mode_i == PCMODE_EDGE) && rising[pn]) ||
+      ((mode_i == PCMODE_FALL || mode_i == PCMODE_EDGE) && falling[pn])
+    );
+  end
+
+  assign pcint_o = pcint_q;
+
+endmodule

--- a/rtl/system/sonata_pkg.sv
+++ b/rtl/system/sonata_pkg.sv
@@ -18,6 +18,12 @@ package sonata_pkg;
   localparam int unsigned PWM_OUT_WIDTH = 7;
   localparam int unsigned SPI_CS_WIDTH = 4;
 
+  // Instance-specific GPIO core input/output widths.
+  // Include the fixed (non-pinmux) GPIO used for on-board peripherals.
+  // Each must be less than GPIO_IOS_WIDTH.
+  localparam int unsigned GPIO_INST_IN_WIDTH[GPIO_NUM+1]  = {17, 28, 14, 8, 8, 6};
+  localparam int unsigned GPIO_INST_OUT_WIDTH[GPIO_NUM+1] = { 8, 28, 14, 8, 8, 6};
+
   // Number of input, output, and inout pins
   localparam int unsigned IN_PIN_NUM = 8;
   localparam int unsigned OUT_PIN_NUM = 15;

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -883,9 +883,11 @@ module sonata_system
   assign gp_o_en           = gpio_to_pins_enable[0];
 
   gpio #(
-    .GpiWidth     ( GPIO_IOS_WIDTH ),
-    .GpoWidth     ( GPIO_IOS_WIDTH ),
-    .NumInstances ( TotalGpioNum   )
+    .GpiMaxWidth  ( GPIO_IOS_WIDTH      ),
+    .GpoMaxWidth  ( GPIO_IOS_WIDTH      ),
+    .NumInstances ( TotalGpioNum        ),
+    .GpiInstWidths( GPIO_INST_IN_WIDTH  ),
+    .GpoInstWidths( GPIO_INST_OUT_WIDTH )
   ) u_gpio (
     .clk_i           (clk_sys_i),
     .rst_ni          (rst_sys_ni),

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -123,9 +123,10 @@ module sonata_system
   localparam int unsigned BusAddrWidth  = 32;
   localparam int unsigned BusByteEnable = 4;
   localparam int unsigned BusDataWidth  = 32;
-  localparam int unsigned RegAddrWidth  = 8;
+  localparam int unsigned PRegAddrWidth = 8;  // PWM uses only 8 bits of addressing.
   localparam int unsigned DRegAddrWidth = 12; // Debug module uses 12 bits of addressing.
   localparam int unsigned TRegAddrWidth = 16; // Timer uses more address bits.
+  localparam int unsigned GRegAddrWidth = 9; // GPIO array uses 9 bits of addressing.
   localparam int unsigned FixedSpiNum   = 2; // Number of SPI devices that don't pass through the pinmux
   localparam int unsigned TotalSpiNum   = SPI_NUM + FixedSpiNum; // The total number of SPI devices
   localparam int unsigned FixedGpioNum  = 1; // Number of GPIO instances that don't pass through the pinmux
@@ -639,7 +640,7 @@ module sonata_system
     // Register interface.
     .re_o         (device_re[Pwm]),
     .we_o         (device_we[Pwm]),
-    .addr_o       (device_addr[Pwm][RegAddrWidth-1:0]),
+    .addr_o       (device_addr[Pwm][PRegAddrWidth-1:0]),
     .wdata_o      (device_wdata[Pwm]),
     .be_o         (device_be[Pwm]),
     .busy_i       ('0),
@@ -648,7 +649,7 @@ module sonata_system
   );
 
   // Tie off upper bits of address.
-  assign device_addr[Pwm][BusAddrWidth-1:RegAddrWidth] = '0;
+  assign device_addr[Pwm][BusAddrWidth-1:PRegAddrWidth] = '0;
 
   tlul_adapter_reg #(
     .RegAw            ( TRegAddrWidth ),
@@ -885,6 +886,9 @@ module sonata_system
   gpio #(
     .GpiMaxWidth  ( GPIO_IOS_WIDTH      ),
     .GpoMaxWidth  ( GPIO_IOS_WIDTH      ),
+    .AddrWidth    ( BusAddrWidth        ),
+    .DataWidth    ( BusDataWidth        ),
+    .RegAddrWidth ( GRegAddrWidth       ),
     .NumInstances ( TotalGpioNum        ),
     .GpiInstWidths( GPIO_INST_IN_WIDTH  ),
     .GpoInstWidths( GPIO_INST_OUT_WIDTH )

--- a/sw/cheri/checks/CMakeLists.txt
+++ b/sw/cheri/checks/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CHECKS
   revocation_test.cc
   rgbled_test.cc
   usbdev_check.cc
+  pcint_check.cc
   pinmux_check.cc
   rs485_check.cc
   rs485_spam_check.cc

--- a/sw/cheri/checks/pcint_check.cc
+++ b/sw/cheri/checks/pcint_check.cc
@@ -1,0 +1,119 @@
+/**
+ * Copyright lowRISC contributors.
+ * Licensed under the Apache License, Version 2.0, see LICENSE for details.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Interact with the Pin-Change Interrupt (PCINT) functionality of the
+ * GPIO using the on-board DIP switches, joystick push-button, and LEDs.
+ *
+ * User DIP switches (SW4) and user LEDs
+ *   US0 / ULED0: mode0
+ *   US1 / ULED1: mode1
+ *   US2 / ULED2:  - unused -
+ *   US3 / ULED3: debounce select
+ *   US4 / ULED4: interrupt enable
+ *   US5 / ULED5:  - unused -
+ *   US6: clear irq_fired    / ULED6: irq_fired
+ *   US7: clear PCINT status / ULED7: PCINT status
+ *
+ * SW8 (joystick)
+ *   push button: input pin state -> release=low, pressed=high
+ */
+
+#define CHERIOT_NO_AMBIENT_MALLOC
+#define CHERIOT_NO_NEW_DELETE
+
+#include <stdint.h>
+
+#include <cheri.hh>
+#include <platform-plic.hh>
+#include "../common/asm.hh"
+#include "../common/sonata-devices.hh"
+
+using namespace CHERI;
+
+PLIC::SonataPlic *plic;
+volatile bool irq_fired;
+Capability<volatile uint32_t> sts;
+
+/**
+ * Overwride the default handler
+ */
+extern "C" void irq_external_handler(void) {
+  if (auto irq = plic->interrupt_claim()) {
+    *sts = *sts;  // clear interrupt at source
+    plic->interrupt_complete(*irq);
+    irq_fired = true;
+  }
+}
+
+/**
+ * C++ entry point for the loader.  This is called from assembly, with the
+ * read-write root in the first argument.
+ */
+extern "C" uint32_t entry_point(void *rwRoot) {
+  Capability<void> root{rwRoot};
+
+  // Capability to general purpose output
+  Capability<volatile uint32_t> gpo = root.cast<volatile uint32_t>();
+  gpo.address()                     = 0x80000000;
+  gpo.bounds()                      = sizeof(uint32_t);
+
+  // Capability to general purpose input
+  Capability<volatile uint32_t> gpi = root.cast<volatile uint32_t>();
+  gpi.address()                     = 0x80000004;
+  gpi.bounds()                      = sizeof(uint32_t);
+
+  // Capability to (PCINT) control
+  Capability<volatile uint32_t> ctl = root.cast<volatile uint32_t>();
+  ctl.address()                     = 0x80000010;
+  ctl.bounds()                      = sizeof(uint32_t);
+
+  // Capability to PCINT status
+  sts           = root.cast<volatile uint32_t>();
+  sts.address() = 0x80000014;
+  sts.bounds()  = sizeof(uint32_t);
+
+  // Capability to PCINT mask
+  Capability<volatile uint32_t> msk = root.cast<volatile uint32_t>();
+  msk.address()                     = 0x80000018;
+  msk.bounds()                      = sizeof(uint32_t);
+
+  PLIC::SonataPlic _plic(root);
+  plic      = &_plic;
+  irq_fired = false;
+  plic->interrupt_enable(PLIC::Interrupts::Pcint);
+  plic->priority_set(PLIC::Interrupts::Pcint, 1);
+  ASM::Ibex::external_interrupt_set(true);
+  ASM::Ibex::global_interrupt_set(true);
+
+  uint32_t inputValue  = 0;
+  uint32_t switchValue = 0;
+  uint32_t ctlValue    = 0;
+  bool statusBit       = 0;
+  bool enableBit       = 0;
+  *msk                 = 0x0400;   // trigger PCINT using joystick button only
+  *sts                 = 1 << 31;  // ensure flag is clear at start
+  while (true) {
+    // Control PCINT using DIP switches
+    inputValue  = *gpi;
+    switchValue = inputValue & 0xFF;
+    statusBit   = (switchValue >> 7) & 0x1;
+    enableBit   = (switchValue >> 4) & 0x1;
+    *ctl        = (enableBit << 31) | (switchValue & 0x0F);
+    *sts        = statusBit << 31;
+
+    // Display PCINT control and status on LEDs
+    ctlValue  = *ctl;
+    enableBit = ctlValue >> 31;
+    statusBit = *sts >> 31;
+    *gpo      = (statusBit << 7) | (irq_fired << 6) | (enableBit << 4) | (ctlValue & 0x0F);
+
+    // Clear our own flag depending on DIP switch
+    if (switchValue & (1 << 6)) irq_fired = false;
+  }
+
+  asm volatile("wfi");
+}

--- a/sw/cheri/common/sonata_plic.hh
+++ b/sw/cheri/common/sonata_plic.hh
@@ -14,6 +14,7 @@ typedef enum : uint32_t {
   HardwareRevoker = 1,
   Ethernet        = 2,
   Usbdev          = 3,
+  Pcint           = 4,
   // Uart Interrupts (up to 8 instances).
   Uart0 = 8,
   // I2c Interrupts (up to 8 instances).

--- a/sw/common/defs.h
+++ b/sw/common/defs.h
@@ -20,7 +20,7 @@
 
 #define GPIO_NUM 6
 #define GPIO_ADDRESS (0x8000'0000)
-#define GPIO_BOUNDS (0x0000'0010)
+#define GPIO_BOUNDS (0x0000'001C)
 #define GPIO_RANGE (0x0000'0040)
 
 #define PWM_NUM 7


### PR DESCRIPTION
Note, waiting on https://github.com/lowRISC/sonata-system/pull/416

This adds the hardware, documentation, and software for GPIO Pin-Change Interrupt logic. This should allow external events to trigger interrupts, albeit in a limited way.

Bitstream utilisation:

| Type | Used | Available | Percentage | Change from 1.2 |
|------|------|-----------|------------|----|
| Slice LUTs | 27,152 | 32,600 | 83.29% | +3.53%pt |
| Slice Registers | 16,540 | 65,200 | 25.37% | +1.24%pt |
| Block RAM Tiles | 41 | 75 | 54.67% | 0%pt |
| DSPs | 13 | 120 | 10.83% | 0%pt |

Compared with: https://github.com/lowRISC/sonata-system/releases/tag/v1.2

Note, part of this increase is from the introduction of the correct synchronisers, perhaps because they cannot be optimised away and in all cases we are specifying wider GPIO instance input/output widths than we actually have input/output lines. I shall look into this.
