### PR TITLE
[rtl] Increase outstanding requests in SRAM wrapper

### DIFF
--- a/rtl/system/sram.sv
+++ b/rtl/system/sram.sv
@@ -59,7 +59,8 @@ module sram #(
   // TL-UL device adapters
   tlul_adapter_sram #(
     .SramAw           ( SramAw ),
-    .EnableRspIntgGen ( 0      )
+    .EnableRspIntgGen ( 0      ),
+    .Outstanding      ( 2      )
   ) sram_a_device_adapter (
     .clk_i,
     .rst_ni,
@@ -96,7 +97,8 @@ module sram #(
 
   tlul_adapter_sram #(
     .SramAw           ( SramAw ),
-    .EnableRspIntgGen ( 0      )
+    .EnableRspIntgGen ( 0      ),
+    .Outstanding      ( 2      )
   ) sram_b_device_adapter (
     .clk_i,
     .rst_ni,


### PR DESCRIPTION
Need a minimum of 2 (this is what is used in OpenTitan) to enable back to back requests without stall cycles.