### PR TITLE
Increase multiplier performance

### DIFF
--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -787,6 +787,7 @@ module sonata_system
     .HeapBase        ( tl_main_pkg::ADDR_SPACE_SRAM        ),
     .TSMapBase       ( tl_main_pkg::ADDR_SPACE_REV_TAG     ),
     .TSMapSize       ( RevTagDepth                         ),
+    .RV32M           ( ibex_pkg::RV32MSingleCycle          ),
     .RV32B           ( ibex_pkg::RV32BFull                 ),
     .ICache          ( 1'b1                                )
   ) u_top_tracing (


### PR DESCRIPTION
Switch to the single-cycle multiplier in Ibex by changing the `RV32M` parameter.
Improves multiplication performance while also reducing LUT usage, as much of it can be mapped to the DSP macros in the FPGA.