### PR TITLE
Use BUFGs for some reset signals

### DIFF
--- a/data/pins_sonata.xdc
+++ b/data/pins_sonata.xdc
@@ -351,3 +351,13 @@ set sync_cells [get_cells -hier -filter {ORIG_REF_NAME == prim_flop_2sync}]
 set sync_clk_in [get_pins -of $sync_cells -filter {REF_PIN_NAME == clk_i}]
 set sync_flops [all_fanout -flat -only_cells -endpoints_only $sync_clk_in]
 set_property ASYNC_REG TRUE $sync_flops
+
+# Use spare global clock-routing resource (BUFG) for high-level reset signals
+# to save data-routing resource and hopefully improve timing.
+# Unfortunately, reset signals are often inverted before use,
+# so the benefit of using BUFGs may be limited.
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets rst_n]
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets rst_sys_n]
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets rst_usb_n]
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets rst_hr_n]
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets u_sonata_system/rst_core_n]

--- a/data/pins_sonata_xl.xdc
+++ b/data/pins_sonata_xl.xdc
@@ -447,3 +447,13 @@ set sync_cells [get_cells -hier -filter {ORIG_REF_NAME == prim_flop_2sync}]
 set sync_clk_in [get_pins -of $sync_cells -filter {REF_PIN_NAME == clk_i}]
 set sync_flops [all_fanout -flat -only_cells -endpoints_only $sync_clk_in]
 set_property ASYNC_REG TRUE $sync_flops
+
+# Use spare global clock-routing resource (BUFG) for high-level reset signals
+# to save data-routing resource and hopefully improve timing.
+# Unfortunately, reset signals are often inverted before use,
+# so the benefit of using BUFGs may be limited.
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets rst_n]
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets rst_sys_n]
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets rst_usb_n]
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets rst_hr_n]
+set_property -dict {KEEP TRUE  CLOCK_BUFFER_TYPE BUFG} [get_nets u_sonata_system/rst_core_n]

--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -246,7 +246,11 @@ module top_sonata
   logic [7:0] user_sw_n;
   logic [2:0] sel_sw_n;
 
-  assign led_bootok = rst_sys_n;
+  // Instantiate OBUF to keep rst_sys_n and led_bootok nets separate
+  OBUF OBUF_led_bootok (
+    .I  ( rst_sys_n  ),
+    .O  ( led_bootok )
+  );
 
   // Switch inputs have pull-ups and switches pull to ground when on. Invert here so CPU sees 1 for
   // on and 0 for off.


### PR DESCRIPTION
Free up some data-routing resource by using global clock-routing resources for some specific high-level reset signals. Not perfect as it drops down to normal data-routing when it gets inverted for use in many places, but does seem to improve timing and routing utilisation a bit.
Might as well, seeing as we were only using 8 of 24 BUFGs.