### PR TITLE
Reduce access latency of GPIO blocks

### DIFF
--- a/rtl/ip/gpio/rtl/gpio.sv
+++ b/rtl/ip/gpio/rtl/gpio.sv
@@ -56,7 +56,6 @@ module gpio #(
     .device_we_i     (device_we),
     .device_be_i     (device_be),
     .device_wdata_i  (device_wdata),
-    .device_rvalid_o (),
     .device_rdata_o  (device_rdata),
 
     .gp_i,
@@ -67,7 +66,7 @@ module gpio #(
   );
 
   tlul_adapter_reg #(
-    .AccessLatency ( 1            ),
+    .AccessLatency ( 0            ),
     .RegAw         ( RegAddrWidth )
   ) gpio_device_adapter (
     .clk_i,


### PR DESCRIPTION
Rework the `gpio_core` to provide response data in the same cycle as the request to reduce the access latency.

Reduce the value of the `AccessLatency` parameter of the TL-UL adapter used to connect the GPIO blocks to the system bus, to match the `gpio_core` read latency changes.