### PR TITLE
CI bitstream failure reporting and tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
     runs-on: [ubuntu-22.04-fpga, sonata]
     env:
       BITSTREAM_PATH: build/lowrisc_sonata_system_0/synth-vivado/lowrisc_sonata_system_0.bit
+      SYNTH_LOG: build/lowrisc_sonata_system_0/synth-vivado/lowrisc_sonata_system_0.runs/synth_1/runme.log
+      IMPL_LOG: build/lowrisc_sonata_system_0/synth-vivado/lowrisc_sonata_system_0.runs/impl_1/runme.log
       TIMING_RPT: build/lowrisc_sonata_system_0/synth-vivado/lowrisc_sonata_system_0.runs/impl_1/top_sonata_timing_summary_postroute_physopted.rpt
       UTILIZATION_RPT: build/lowrisc_sonata_system_0/synth-vivado/lowrisc_sonata_system_0.runs/impl_1/top_sonata_utilization_placed.rpt
       GS_PATH: gs://lowrisc-ci-cache/lowRISC/sonata-system/bitstream
@@ -130,6 +132,13 @@ jobs:
       run: |
         module load xilinx/vivado
         nix run .#bitstream-build
+
+    # Only runs if there's been a failure in a previous step.
+    - name: Print failed bitstream logs
+      if: ${{ failure() }}
+      run: |
+        cat $SYNTH_LOG
+        cat $IMPL_LOG
 
     - name: Upload implementation reports
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # We only write to the cache when merging into main, so we don't need th autenticate on pull-request.
+    # We only write to the cache when merging into main, so we don't need th authenticate on pull-request.
     - uses: google-github-actions/auth@v2
       if: github.event_name != 'pull_request'
       with:
@@ -110,7 +110,7 @@ jobs:
           substituters = https://nix-cache.lowrisc.org/public/ https://cache.nixos.org/
           trusted-public-keys = nix-cache.lowrisc.org-public-1:O6JLD0yXzaJDPiQW1meVu32JIDViuaPtGDfjlOopU7o= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
-    # Check if there's a bitstream in the cache that maches the RTL hash computed by Nix.
+    # Check if there's a bitstream in the cache that matches the RTL hash computed by Nix.
     - name: Check bitstream cache
       run: |
         BITSTREAM_HASH=$(nix eval .#filesets.x86_64-linux.bitstreamDependancies.outPath --raw \
@@ -128,7 +128,7 @@ jobs:
     # Only runs if the bitstream does not exist (not found in cache).
     - name: Build bitstream
       id: build_bitstream
-      if: env.file_exists == 'false' 
+      if: env.file_exists == 'false'
       run: |
         module load xilinx/vivado
         nix run .#bitstream-build
@@ -148,9 +148,9 @@ jobs:
           ${{ env.TIMING_RPT }}
           ${{ env.UTILIZATION_RPT }}
 
-    # Only upload the bistream if this is not a pull-request and the build bistream step ran. 
+    # Only upload the bitstream if this is not a pull-request and the build bitstream step ran.
     - name: Upload bitstream to the cache
-      if: github.event_name != 'pull_request' && env.file_exists == 'false' 
+      if: github.event_name != 'pull_request' && env.file_exists == 'false'
       run: |
         BITSTREAM_HASH=$(nix eval .#filesets.x86_64-linux.bitstreamDependancies.outPath --raw \
           | cut -d '/' -f4 | cut -d '-' -f1)


### PR DESCRIPTION
Main change is adding a step to the FPGA CI job to print the contents of the Vivado bitstream build logs when the build fails. This should greatly aid debugging (assuming it works).

Also tidied some typos and trailing whitespace in ci.yml while I was in there.