### PR TITLE
HyperRAM clocking scheme, HBMC bring up and W956 simulation model

### DIFF
--- a/dv/models/fpga/rtl/IOBUF.v
+++ b/dv/models/fpga/rtl/IOBUF.v
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a crude model of the Xilinx IOBUF primitive; enough to make the
+// OpenHBMC implementation simulate correctly.
+module IOBUF #(
+  parameter DRIVE = 0,
+  parameter SLEW  = "SLOW"
+) (
+  output O,
+  inout  IO,
+  input  I,
+  input  T
+);
+
+assign O = IO;
+assign IO = T ? 1'bZ : I;
+
+endmodule
+

--- a/dv/models/fpga/rtl/ISERDESE2.v
+++ b/dv/models/fpga/rtl/ISERDESE2.v
@@ -1,0 +1,83 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a crude model of the Xilinx ISERDESE2 primitive; enough to make the
+// OpenHBMC implementation simulate correctly.
+module ISERDESE2 #(
+  parameter SERDES_MODE       = "MASTER",
+  parameter INTERFACE_TYPE    = "NETWORKING",
+  parameter DATA_RATE         = "DDR",
+  parameter DATA_WIDTH        = 6,
+  parameter DYN_CLKDIV_INV_EN = "FALSE",
+  parameter DYN_CLK_INV_EN    = "FALSE",
+  parameter OFB_USED          = "NONE",
+  parameter IOBDELAY          = 0,
+  parameter NUM_CE            = 1,
+  parameter INIT_Q1           = 1'b0,
+  parameter INIT_Q2           = 1'b0,
+  parameter INIT_Q3           = 1'b0,
+  parameter INIT_Q4           = 1'b0,
+  parameter SRVAL_Q1          = 1'b0,
+  parameter SRVAL_Q2          = 1'b0,
+  parameter SRVAL_Q3          = 1'b0,
+  parameter SRVAL_Q4          = 1'b0
+) (
+  output  O,
+
+  output  Q1,
+  output  Q2,
+  output  Q3,
+  output  Q4,
+  output  Q5,
+  output  Q6,
+  output  Q7,
+  output  Q8,
+
+  input   BITSLIP,
+
+  input   CE1,
+  input   CE2,
+
+  input   CLK,
+  input   CLKB,
+
+  input   CLKDIV,
+  input   CLKDIVP,
+  input   OCLK,
+  input   OCLKB,
+
+  input   D,
+  input   DDLY,
+
+  input   OFB,
+  input   RST,
+
+  input   DYNCLKDIVSEL,
+  input   DYNCLKSEL,
+
+  output  SHIFTOUT1,
+  output  SHIFTOUT2,
+
+  input   SHIFTIN1,
+  input   SHIFTIN2
+);
+
+  reg [8:1] iserdes_int;
+  always @(edge CLK or posedge RST) begin
+    if (RST) begin
+      iserdes_int <= {2{SRVAL_Q4, SRVAL_Q3, SRVAL_Q2, SRVAL_Q1}};
+    end else begin
+      iserdes_int <= {iserdes_int[7:1], D};
+    end
+  end
+
+  // In the ISERDESE2 module, Q8 is the oldest bit received.
+  assign {Q8,Q7,Q6,Q5,Q4,Q3,Q2,Q1} = iserdes_int;
+  assign O = D;
+
+  // These outputs are unused.
+  assign {SHIFTOUT2, SHIFTOUT1} = 2'b0;
+
+endmodule
+

--- a/dv/models/fpga/rtl/OBUF.v
+++ b/dv/models/fpga/rtl/OBUF.v
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a crude model of the Xilinx OBUF primitive; enough to make the
+// OpenHBMC implementation simulate correctly.
+module OBUF #(
+  parameter DRIVE = 0,
+  parameter SLEW  = "SLOW"
+) (
+  input  I,
+  output O
+);
+
+assign O = I;
+
+endmodule
+

--- a/dv/models/fpga/rtl/ODDR.v
+++ b/dv/models/fpga/rtl/ODDR.v
@@ -1,0 +1,52 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a crude model of the Xilinx ODDR primitive; enough to make the
+// OpenHBMC implementation simulate correctly.
+module ODDR #(
+  parameter DDR_CLK_EDGE = "SAME_EDGE",
+  parameter INIT         = 1'b0,
+  parameter SRTYPE       = "ASYNC"
+) (
+  output Q,   // DDR output.
+  input  C,   // Clock input.
+  input  CE,  // Clock Enable.
+  input  D1,  // Two data inputs.
+  input  D2,
+  input  R,   // ReSet inputs.
+  input  S
+);
+
+  // Phase detection; PH is asserted during the second (negative edge)
+  // phase of the clock 'C.'
+  //         ___     ___
+  // C   ___/   \___/   \___
+  // PH   1   0   1   0   1
+
+  reg PH, PC, NC;
+  always @(posedge C) PC <= !PC;
+  always @(negedge C) NC <= !NC;
+  assign PH = !(PC ^ NC);
+
+  reg S2;
+  if (DDR_CLK_EDGE == "SAME_EDGE") begin : gen_same_edge
+    // Both data inputs are presented together on posedge.
+    always @(posedge C) begin
+      if (CE) S2 <= D2;
+    end
+  end else begin : gen_opposite_edge
+    // Inputs are presented on opposite edges.
+    assign S2 = D2;
+  end
+
+  // Output is clocked on both edges of clock input 'C'.
+  reg OUT;
+  always @(edge C, posedge R, posedge S) begin
+    if (R || S) OUT <= S & ~R;
+    else if (CE) OUT <= PH ? D1 : S2;
+  end
+  assign Q = OUT;
+
+endmodule
+

--- a/dv/models/hyperram/rtl/hyperram_W956.sv
+++ b/dv/models/hyperram/rtl/hyperram_W956.sv
@@ -1,0 +1,324 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is a basic functional model of a HyperRAM device for simulation,
+// based on the W956D8MBYA.
+//
+// Presently it has the following limitations:
+// - It does not model internal refresh operations, so it has a fixed access latency.
+// - It does not drive RWDS during the command-address interval, but since Verilator
+//   holds the signal low in this case, the behaviour is as intended.
+// - Register reading is not implemented; the HyperBus controller being used does
+//   not issue register reads as it stands.
+//
+// See the W956D8MBYA datasheet for details. The following is a quick sketch to
+// aid understanding. In particular, note that the clock - which is differential to
+// support DDR - is received only when a transfer is occurring:
+//     _______                                                           ___________
+// csn        \_________________________________________________________/
+//                ___     ___     ___     ___     ___     ___     ___
+// ckp __________|   \___|   \___|   \___|   \___|   \___|   \___|   \______________
+//     __________     ___     ___     ___     ___     ___     ___     ______________
+// ckn           \___|   \___|   \___|   \___|   \___|   \___|   \___|
+//               __  __  __  __  __  __  __  __
+// rwds/ _______|  \|  \|  \|  \|  \|  \|  \|  \
+// dq           \__|\__|\__|\__|\__|\__|\__|\__|
+//
+// Both the read/write strobes (rwds) and data (dq) are sampled on both clock edges.
+// Note that data is transferred as 16-bit Big Endian words.
+
+module hyperram_W956(
+  // Asynchronous reset.
+  input       rstn,
+  // Differential clocking (DDR).
+  input       ckp,
+  input       ckn,
+  // Chip Select.
+  input       csn,
+  // Bidirectional read/write data strobe.
+  inout       rwds,
+  // Bidirectional data bus.
+  inout [7:0] dq
+);
+  // Report memory and register traffic occurring within the HyperRAM model?
+  localparam bit HyperRAM_Logging = 1'b0;
+
+  // HyperRAM storage.
+  logic [21:0] hram_addr;
+  logic [15:0] hram_wdata;
+  logic [15:0] hram_wmask;
+  logic [15:0] hram_rdata;
+  logic        hram_we;
+  logic [1:0]  hram_be;
+
+  // Expand the write strobes to bit level as required by the memory model.
+  assign hram_wmask = {{8{hram_be[1]}}, {8{hram_be[0]}}};
+
+  prim_ram_2p #(
+    .Width           (16),
+    .Depth           ('h40_0000),
+    .DataBitsPerMask (8),
+    .MemInitFile     ()
+  ) u_ram(
+    // Reads are performed on the rising edge of the positive clock (CK)
+    // and the read data is returned combinationally.
+    .clk_a_i    (ckp),
+    // Writes are performed on the rising edge of the negative clock (CK#)
+    // once the entire 16-bit word has been received. Note that there is not
+    // necessarily another clock edge after that because CK/CK# are static
+    // when not transferring data over the HyperBus.
+    .clk_b_i    (ckn),
+
+    // Read port.
+    .a_req_i    (hram_re),
+    .a_write_i  (1'b0),
+    .a_addr_i   (hram_addr),
+    .a_wdata_i  ('0),
+    .a_wmask_i  ('0),
+    .a_rdata_o  (hram_rdata),
+
+    // Write port.
+    .b_req_i    (hram_we),
+    .b_write_i  (1'b1),
+    .b_addr_i   (hram_addr),
+    .b_wdata_i  (hram_wdata),
+    .b_wmask_i  (hram_wmask),
+    .b_rdata_o  (),
+
+    .cfg_i      ('0)
+   );
+
+  // HyperRAM model; this is a very basic model, just enough to allow us to simulate
+  // actual usage. Note that the timing is not completely accurate because there is
+  // no effort to simulate the variable latency that results from internal refresh
+  // activity.
+  typedef enum logic [3:0] {
+    HRAM_Cmd0,
+    HRAM_Cmd1,
+    HRAM_Cmd2,
+    HRAM_Cmd3,
+    HRAM_Cmd4,
+    HRAM_Cmd5,
+    HRAM_Latency1,
+    HRAM_Latency2,
+    HRAM_Writing,  // Actively collecting write data until CS raised.
+    HRAM_Reading,  // Actively returning read data until CS raised.
+    HRAM_RegWriting,  // Two cycles of register write data.
+    // The HyperBus Memory Controller that we use does not issues register reads.
+    HRAM_Ignoring  // Ignoring register read.
+  } hram_state_e;
+
+  logic hram_re;
+  assign hram_we = &{hram_state == HRAM_Writing, !csn};
+  assign hram_re = &{hram_state == HRAM_Reading, !csn};
+
+  hram_state_e hram_state;
+  logic [2:0] hram_cmd;
+  logic [4:0] hram_lat;
+  // High byte of current 16-bit write operation.
+  logic [7:0] hram_wdata_hi;
+  // Write strobe for high byte.
+  logic hram_wmask_hi;
+  logic hram_lsb;  // LSByte within the current word?
+
+  // Write data and strobes.
+  assign hram_be[1] = hram_wmask_hi;
+  assign hram_be[0] = !rwds;
+  assign hram_wdata = {hram_wdata_hi, dq};
+
+  // Read data path.
+  logic hram_drv_oe;
+  logic hram_rd_sel;
+  logic hram_rd_lsb;
+  // Selected byte; MS byte is returned first.
+  wire [7:0] hram_rd_byte = hram_rd_lsb ? hram_rdata[7:0] : hram_rdata[15:8];
+
+  // Burst wrapping.
+  logic burst_end;
+  logic burst_wrap;
+  always_comb begin
+    burst_end = &{hram_addr[5:0], hram_lsb};  // 128 bytes
+    case (burst_len)
+      2'b01:   burst_end = &{hram_addr[4:0], hram_lsb};  // 64 bytes
+      2'b10:   burst_end = &{hram_addr[2:0], hram_lsb};  // 16 bytes
+      2'b11:   burst_end = &{hram_addr[3:0], hram_lsb};  // 32 bytes
+      default: /* see default assignment above */;
+    endcase
+  end
+  logic [21:0] hram_base;
+  always_comb begin
+    hram_base = {hram_addr[21:6], 6'b0};
+    case (burst_len)
+      2'b01:   hram_base = {hram_addr[21:5], 5'b0};
+      2'b10:   hram_base = {hram_addr[21:3], 3'b0};
+      2'b11:   hram_base = {hram_addr[21:4], 4'b0};
+      default: /* see default assignment above */;
+    endcase
+  end
+  assign burst_wrap = !hram_cmd[0];  // Wrapping, rather than linear burst.
+
+  // Address for next transfer; bursts may be wrapping or linear. A linear burst just
+  // continues incrementing the address indefinitely.
+  logic [21:0] next_addr;
+  assign next_addr = (burst_end & burst_wrap) ? hram_base : (hram_addr + 22'(hram_lsb));
+
+  // Configuration Register 0 state.
+  logic [3:0] latency_initial;
+  logic       latency_fixed;
+  logic       burst_hybrid;  // Note: Hybrid burst mode is not required at present.
+  logic [1:0] burst_len;
+
+  // Configuration Register 1 state.
+  //
+  // Note: We currently don't model this register/functionality; it is concerned with sleep mode
+  // and refresh functionality.
+
+  // Configuration register write.
+  wire hram_cfg_we = &{hram_state == HRAM_RegWriting, !csn};
+  // Note: We do not implement register reading because the HBMC does not use it.
+
+  // We need only be concerned with Configuration Register 0 and Configuration Register 1 writes,
+  // and chiefly to ignore writes to register 1 which we presently do not model.
+  wire hram_cfg_reg = hram_addr[0];
+  wire [15:0] hram_cfg_wdata = {hram_wdata_hi, dq};
+
+  always_ff @(posedge ckn, negedge rstn) begin
+    if (!rstn) begin
+      // Configuration Register 0.
+      latency_initial <= 4'b0010;  // Default 7 Clock Latency @ 200MHz.
+      latency_fixed <= 1'b1;  // Default is 2 times Initial Latency.
+      burst_hybrid <= 1'b1;  // Legacy wrapped bursts are the default.
+      burst_len <= 2'b11;  // Default to 32-byte bursts when wrapping.
+    end else if (hram_cfg_we & ~hram_cfg_reg) begin
+      latency_initial <= hram_cfg_wdata[7:4];
+      latency_fixed <= hram_cfg_wdata[3];
+      burst_hybrid <= hram_cfg_wdata[2];
+      burst_len <= hram_cfg_wdata[1:0];
+    end
+  end
+
+  // Logging of RAM and Register activity.
+  if (HyperRAM_Logging) begin : logging
+    // Memory traffic.
+    logic [21:0] hram_addr_del;
+    logic hram_re_del;
+    always_ff @(posedge ckn) begin : logging_mem
+      hram_re_del <= hram_re;
+      hram_addr_del <= hram_addr;
+      // Writes occur on the rising edge of ckn, so the write inputs are available at this point.
+      if (hram_we) begin
+        $display("%t: HR write 0x%0x : %02b : 0x%04x", $realtime, hram_addr, hram_be, hram_wdata);
+      end
+      // Reads occur on the rising edge of ckp, but we want to report the new state of `hram_rdata.`
+      if (hram_re_del) begin
+        $display("%t: HR read 0x%0x -> 0x%04x", $realtime, hram_addr_del, hram_rdata);
+      end
+    end : logging_mem
+    // Register traffic.
+    always_ff @(posedge ckn) begin : logging_reg
+      if (hram_cfg_we) begin
+        $display("%t: HR reg write 0x%0x : 0x%04x", $realtime, hram_cfg_reg, hram_cfg_wdata);
+      end
+    end : logging_reg
+  end : logging
+
+  // HyperRAM model state machine.
+  // Note: this logic is active on _both_ edges of _ckp, so it does not use _ckn.
+  //
+  // csn is used as an asynchronous reset because the clock is not running when
+  // this active low Chip Select signal is deasserted.
+  always_ff @(edge ckp, posedge csn, negedge rstn) begin
+    if (!rstn || csn) begin
+      // The state machine sits in Cmd0 awaiting capture of the first command
+      // byte when first it is clocked.
+      hram_state <= HRAM_Cmd0;
+      hram_drv_oe <= 1'b0;
+    end else begin
+      case (hram_state)
+        HRAM_Cmd0: hram_state <= HRAM_Cmd1;
+        HRAM_Cmd1: hram_state <= HRAM_Cmd2;
+        HRAM_Cmd2: hram_state <= HRAM_Cmd3;
+        HRAM_Cmd3: hram_state <= HRAM_Cmd4;
+        HRAM_Cmd4: hram_state <= HRAM_Cmd5;
+        HRAM_Cmd5: begin
+          case (hram_cmd[2:1])
+            2'b11:   hram_state <= HRAM_Ignoring;    // Register reads are ignored.
+            2'b01:   hram_state <= HRAM_RegWriting;  // No latency on register writes.
+            default: hram_state <= HRAM_Latency1;    // Memory access.
+          endcase
+        end
+        HRAM_Latency1: if (~|hram_lat) hram_state <= hram_cmd[2] ? HRAM_Reading : HRAM_Writing;
+        HRAM_Ignoring,
+        HRAM_RegWriting,
+        HRAM_Reading,
+        HRAM_Writing: /* these states persist until CS deasserted */;
+        default: hram_state <= HRAM_Cmd0;
+      endcase
+      case (hram_state)
+        HRAM_Cmd0: hram_cmd         <= dq[7:5];
+        HRAM_Cmd1: hram_addr[21:19] <= dq[2:0];
+        HRAM_Cmd2: hram_addr[18:11] <= dq;
+        HRAM_Cmd3: hram_addr[10:3]  <= dq;
+        HRAM_Cmd4: /* reserved data */;
+        HRAM_Cmd5: begin
+          hram_addr[2:0] <= dq[2:0];
+          hram_lsb       <= 1'b0;
+          // Initialise latency counter; note that we're counting on both clock edges
+          // but the programmed latency count is in clock cycles. We also count from [N-1:0],
+          // making the mapping from the 'clock latency' in the W956 datasheet to our
+          // initial counter value n -> 2(n-1)-1.
+          case (latency_initial)
+            4'b0000: hram_lat <= 5'h7 << latency_fixed;  // 5 Clock Latency @ 133MHz.
+            4'b0001: hram_lat <= 5'h9 << latency_fixed;  // 6 Clock Latency @ 166MHz.
+            4'b0010: hram_lat <= 5'hB << latency_fixed;  // 7 Clock Latency @ 200MHz.
+            4'b1110: hram_lat <= 5'h3 << latency_fixed;  // 3 Clock Latency @ 83MHz.
+            default: hram_lat <= 5'h5 << latency_fixed;  // 4 Clock Latency @ 100MHz.
+          endcase
+          // TODO: Perhaps make some effort to model the variable latency of a real device?
+          // Read state.
+          hram_rd_sel    <= 1'b1;
+          hram_rd_lsb    <= 1'b0;
+        end
+        HRAM_Latency1: hram_lat <= hram_lat - 'b1;
+        HRAM_RegWriting: begin
+          // Retain the upper bytes of the register write data.
+          if (!hram_lsb) hram_wdata_hi <= dq;
+          hram_lsb <= !hram_lsb;
+        end
+        HRAM_Writing: begin
+          // Retain the MS byte of each 16-bit word received.
+          if (!hram_lsb) begin
+            hram_wmask_hi <= ~rwds;
+            hram_wdata_hi <= dq;
+          end
+          // Advance the addressing; MS byte of each word is received first.
+          hram_lsb  <= !hram_lsb;
+          hram_addr <= next_addr;
+        end
+        HRAM_Reading: begin
+          // Advance the addressing; MS byte of each word is returned first.
+          hram_lsb  <= !hram_lsb;
+          hram_addr <= next_addr;
+        end
+        default: /* do nothing */;
+      endcase
+      hram_drv_oe <= hram_re;
+      if (hram_drv_oe) begin
+        hram_rd_lsb <= !hram_rd_lsb;  // Next byte within 16-bit word.
+        hram_rd_sel <= hram_rd_sel ^ hram_rd_lsb;  // Advance after LSB.
+      end
+    end
+  end
+
+  // Read data from HyperRAM model.
+  assign dq = hram_drv_oe ? hram_rd_byte : {8{1'bz}};
+  // Read strobes from HyperRAM model.
+  assign rwds = hram_drv_oe ? !hram_rd_lsb : 1'bz;
+
+  // Some signals have unused bits; use them here to prevent warnings/errors.
+  logic unused_hyperram;
+  assign unused_hyperram = ^{hram_cfg_wdata, burst_hybrid};
+
+endmodule
+

--- a/dv/verilator/sonata_system.cc
+++ b/dv/verilator/sonata_system.cc
@@ -38,12 +38,54 @@ int SonataSystem::Main(int argc, char **argv) {
 int SonataSystem::Setup(int argc, char **argv, bool &exit_app) {
   VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
 
-  simctrl.SetTop(&_top, &_top.clk_i, &_top.rst_ni,
+  // Just a single reset signal for all clock domains.
+  simctrl.SetTop(&_top, &_top.rst_ni,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
   _memutil.RegisterMemoryArea("ram", 0x100000, &_ram);
   _memutil.RegisterMemoryArea("hyperram", 0x40000000, &_hyperram);
   simctrl.RegisterExtension(&_memutil);
+
+  // Create our clocks with their default properties.
+  //
+  // 40MHz System Clock, no jitter.
+  // 48MHz USB Clock, no jitter.
+  // 100MHz HyperRAM clocks, no jitter.
+  // 300MHz HyperRAM clock, no jitter.
+  //
+  // All times are in picoseconds for greater accuracy.
+  const uint32_t nano = 1000u;  // in ps.
+  const uint32_t micro = 1000u * nano;
+  const uint32_t milli = 1000u * micro;
+  const uint32_t sys_hperiod = micro / 80u;  // 40MHz cycle
+
+  // Main system clock must be added first.
+  VerilatorSimClock clk_sys(&_top.clk_i, sys_hperiod, sys_hperiod);
+  simctrl.AddClock(clk_sys);
+
+  // The design may run on a single clock for faster simulations.
+#ifdef USE_SEPARATED_CLOCKS
+  uint32_t usb_hperiod  = micro / 96u;   // 48MHz cycle
+  // Note: calculate the period of the higher frequency clock first because
+  // the period of the 'hr' reference clock must be exactly 3 times longer
+  // to maintain the phase relationship.
+  uint32_t hr3x_hperiod = (micro + 599u) / 600u;  // 300MHz cycle
+  uint32_t hr_hperiod = 3 * hr3x_hperiod;  // 100MHz cycle
+
+  // The HyperRAM requires a clock that is phase-shifted by 90 degress.
+  uint32_t hr90p_offset = hr_hperiod / 2;
+
+  // Supplementary clocks.
+  VerilatorSimClock clk_usb(&_top.clk_usb_i, usb_hperiod, usb_hperiod);
+  VerilatorSimClock clk_hr(&_top.clk_hr_i, hr_hperiod, hr_hperiod);
+  VerilatorSimClock clk_hr90p(&_top.clk_hr90p_i, hr_hperiod, hr_hperiod, hr90p_offset);
+  VerilatorSimClock clk_hr3x(&_top.clk_hr3x_i, hr3x_hperiod, hr3x_hperiod);
+
+  simctrl.AddClock(clk_usb);
+  simctrl.AddClock(clk_hr);
+  simctrl.AddClock(clk_hr90p);
+  simctrl.AddClock(clk_hr3x);
+#endif
 
   exit_app = false;
   return simctrl.ParseCommandArgs(argc, argv, exit_app);

--- a/dv/verilator/sonata_system.cc
+++ b/dv/verilator/sonata_system.cc
@@ -16,7 +16,11 @@
 SonataSystem::SonataSystem(const char *ram_hier_path, int ram_size_words,
   const char *hyperram_hier_path, int hyperram_size_words)
     : _ram(ram_hier_path, ram_size_words, 4),
+#ifdef USE_HYPERRAM_SIM_MODEL
       _hyperram(hyperram_hier_path, hyperram_size_words, 4) {}
+#else
+      _hyperram(hyperram_hier_path, hyperram_size_words / 2, 2) {}
+#endif
 
 int SonataSystem::Main(int argc, char **argv) {
   bool exit_app;

--- a/dv/verilator/sonata_system_main.cc
+++ b/dv/verilator/sonata_system_main.cc
@@ -8,7 +8,13 @@ int main(int argc, char **argv) {
   SonataSystem sonata_system(
       "TOP.top_verilator.u_sonata_system.u_sram_top.u_ram.gen_generic.u_impl_generic",
       32 * 1024, // 32k words = 128 KiB
+#ifdef USE_HYPERRAM_SIM_MODEL
+      // Simple SRAM model used within the Sonata System for faster simulations.
       "TOP.top_verilator.u_sonata_system.u_hyperram.u_hyperram_model.u_ram.gen_generic.u_impl_generic",
+#else
+      // HyperRAM simulation model external to the Sonata System; driven by HBMC.
+      "TOP.top_verilator.u_hyperram_W956.u_ram.gen_generic.u_impl_generic",
+#endif
       256 * 1024 // 256k words = 1 MiB
   );
 

--- a/dv/verilator/sonata_verilator_lint.vlt
+++ b/dv/verilator/sonata_verilator_lint.vlt
@@ -94,6 +94,27 @@ lint_off -rule UNOPTFLAT -file "*/rtl/ibex_id_stage.sv" -match "*Signal unoptimi
 // Build warns of circular logic, but this is functioning correctly so it is safe to ignore.
 lint_off -rule UNOPTFLAT -file "*/rtl/ibexc_top_tracing.sv" -match "*rvfi_rd_addr*"
 
+// Disable warnings within the HyperRAM controller.
+lint_off -rule CASEINCOMPLETE -file "*hbmc_ctrl.v"
+lint_off -rule REALCVT -file "*hbmc_ctrl.v"
+lint_off -rule UNOPTFLAT -file "*hbmc_ctrl.v"
+lint_off -rule UNUSED -file "*hbmc_ctrl.v"
+lint_off -rule WIDTHEXPAND -file "*hbmc_ctrl.v"
+lint_off -rule WIDTHTRUNC -file "*hbmc_ctrl.v"
+lint_off -rule WIDTHEXPAND -file "*hbmc_iobuf.v"
+lint_off -rule WIDTHTRUNC -file "*hbmc_iobuf.v"
+lint_off -rule UNUSED -file "*hbmc_clk_obuf.v"
+lint_off -rule UNUSED -file "*hbmc_iobuf.v"
+
+lint_off -rule UNOPTFLAT -file "*hbmc_tl_top.sv"
+lint_off -rule UNUSED -file "*hbmc_tl_top.sv"
+
+// Disable warnings in models of FPGA primitives.
+lint_off -rule UNUSED -file "*IOBUF.v"
+lint_off -rule UNUSED -file "*ISERDESE2.v"
+lint_off -rule UNUSED -file "*OBUF.v"
+lint_off -rule UNUSED -file "*ODDR.v"
+
 // Bug seem in Verilator v5.020 where trace chandles produces a C++ compilation
 // error (generated C++ doesn't currently specify a type an internal verilator
 // function)

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -178,6 +178,14 @@ module top_verilator #(
                       rph_g16_ce2, rph_g8_ce0, rph_g7_ce1,
                       usrLed};
 
+  // HyperRAM interface.
+  wire [7:0]  hyperram_dq;
+  wire        hyperram_rwds;
+  wire        hyperram_ckp;
+  wire        hyperram_ckn;
+  wire        hyperram_nrst;
+  wire        hyperram_cs;
+
   // Reporting of CHERI enable/disable and any exceptions that occur.
   wire  [CheriErrWidth-1:0] cheri_err;
   logic [CheriErrWidth-1:0] cheri_errored;
@@ -422,13 +430,12 @@ module top_verilator #(
 
     .rgbled_dout_o (),
 
-    // SRAM model used for hyperram so don't connect hyperram IO
-    .hyperram_dq  (),
-    .hyperram_rwds(),
-    .hyperram_ckp (),
-    .hyperram_ckn (),
-    .hyperram_nrst(),
-    .hyperram_cs  (),
+    .hyperram_dq      (hyperram_dq),
+    .hyperram_rwds    (hyperram_rwds),
+    .hyperram_ckp     (hyperram_ckp),
+    .hyperram_ckn     (hyperram_ckn),
+    .hyperram_nrst    (hyperram_nrst),
+    .hyperram_cs      (hyperram_cs),
 
     .rs485_tx_enable_o(rs485_tx_enable),
     .rs485_rx_enable_o(rs485_rx_enable),
@@ -654,6 +661,21 @@ module top_verilator #(
     .active(1'b1       ),
     .tx_o  (rs485_uartdpi_tx),
     .rx_i  (rs485_uartdpi_rx)
+  );
+
+  // HyperRAM model (based on W956D8MBYA5I).
+  hyperram_W956 u_hyperram_W956 (
+    // Asynchronous reset signal.
+    .rstn   (hyperram_nrst),
+    // Differential clocking for DDR.
+    .ckp    (hyperram_ckp),
+    .ckn    (hyperram_ckn),
+    // Chip Select.
+    .csn    (hyperram_cs),
+    // Bidirectional read/write data strobe.
+    .rwds   (hyperram_rwds),
+    // Bidirectional data bus.
+    .dq     (hyperram_dq)
   );
 
   export "DPI-C" function mhpmcounter_get;

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -1239,6 +1239,9 @@ module sonata_system
     .td_o
   );
 
+  // Debug module is not capability-aware.
+  assign host_wcap[DbgHost] = 1'b0;
+
   system_info #(
     .SysClkFreq (   SysClkFreq ),
     .GpioNum    ( TotalGpioNum ),

--- a/sonata.core
+++ b/sonata.core
@@ -54,6 +54,11 @@ filesets:
       - dv/dpi/spidpi/spi_lcd.hh: { file_type: cppSource, is_include_file: true }
       - dv/dpi/spidpi/spi_microsd.cc: { file_type: cppSource }
       - dv/dpi/spidpi/spi_microsd.hh: { file_type: cppSource, is_include_file: true }
+      - dv/models/hyperram/rtl/hyperram_W956.sv: { file_type: systemVerilogSource }
+      - dv/models/fpga/rtl/IOBUF.v: { file_type: systemVerilogSource }
+      - dv/models/fpga/rtl/ISERDESE2.v: { file_type: systemVerilogSource }
+      - dv/models/fpga/rtl/OBUF.v: { file_type: systemVerilogSource }
+      - dv/models/fpga/rtl/ODDR.v: { file_type: systemVerilogSource }
       - dv/verilator/top_verilator.sv: { file_type: systemVerilogSource }
       - dv/verilator/sonata_system.cc: { file_type: cppSource }
       - dv/verilator/sonata_system.hh:  { file_type: cppSource, is_include_file: true }
@@ -168,7 +173,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_verilator"'
+          - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_verilator -DUSE_HYPERRAM_SIM_MODEL"'
           # Add "-DUSE_SEPARATED_CLOCKS" to CFLAGS for a more accurate simulation.
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"

--- a/sonata.core
+++ b/sonata.core
@@ -94,6 +94,11 @@ parameters:
     #default: "../../../../../sw/legacy/build/boot/boot.vmem"
     paramtype: vlogparam
 
+  USE_SEPARATED_CLOCKS:
+    datatype: bool
+    paramtype: vlogdefine
+    description: Use separate clocks for a more accurate, but slower, simulation.
+
   # For value definition, please see ip/prim/rtl/prim_pkg.sv
   PRIM_DEFAULT_IMPL:
     datatype: str
@@ -164,6 +169,7 @@ targets:
           - '--trace-params'
           - '--trace-max-array 1024'
           - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_verilator"'
+          # Add "-DUSE_SEPARATED_CLOCKS" to CFLAGS for a more accurate simulation.
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           - "-Wwarn-IMPERFECTSCH"
@@ -171,6 +177,7 @@ targets:
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"
     parameters:
+      - USE_SEPARATED_CLOCKS=false
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
       - USE_HYPERRAM_SIM_MODEL=true
 

--- a/sw/cheri/tests/hyperram_tests.hh
+++ b/sw/cheri/tests/hyperram_tests.hh
@@ -115,7 +115,7 @@ int rand_data_addr_test(Capability<volatile uint32_t> hyperram_area, ds::xoroshi
 /*
  * Writes a random value to a random address and then writes a capability for
  * that random address to another random location. Reads back the capability and
- * then reads back the value via the capability to check it matches what we was
+ * then reads back the value via the capability to check it matches what was
  * originally written.
  */
 int rand_cap_test(Capability<volatile uint32_t> hyperram_area,

--- a/vendor/lowrisc_ibex/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_clock.h
+++ b/vendor/lowrisc_ibex/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_clock.h
@@ -1,0 +1,111 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_VERILATOR_SIMUTIL_VERILATOR_CPP_VERILATOR_SIM_CLOCK_H_
+#define OPENTITAN_HW_DV_VERILATOR_SIMUTIL_VERILATOR_CPP_VERILATOR_SIM_CLOCK_H_
+#include <cassert>
+#include <cstdint>
+
+#include "verilated_toplevel.h"
+
+/**
+ * Clock signal in Verilated top level.
+ */
+class VerilatorSimClock {
+ public:
+  /**
+   * Initialize a clock signal with its properties.
+   * All time parameters are specified in picoseconds for accuracy.
+   *
+   * @param sig_clk Signal in the Verilated top level object.
+   * @param hi_interval Time interval for the 'hi' phase of the clock, in ps.
+   * @param lo_interval Time interval for the 'lo' phase of the clock, in ps.
+   * @param init_offset Time interval until the first transition of the clock, in ps.
+   * @param hi_jitter Amount by which 'hi_interval' may vary, in picoseconds.
+   * @param lo_jitter Amount by which 'lo_interval' may vary, in picoseconds.
+   */
+  VerilatorSimClock(CData *sig_clk, uint32_t hi_interval, uint32_t lo_interval,
+                    uint32_t init_offset = 0u, uint32_t hi_jitter = 0u, uint32_t lo_jitter = 0u)
+      : sig_clk_(sig_clk),
+        hi_interval_(hi_interval),
+        lo_interval_(lo_interval),
+        hi_jitter_(hi_jitter),
+        lo_jitter_(lo_jitter),
+        lfsr_(1u),
+        del_(init_offset) {
+    // Each clock interval (hi/lo) is permitted to vary in the range
+    // (-jitter/2, +jitter/2)
+    assert(hi_jitter < hi_interval && lo_jitter < lo_interval);
+  }
+
+  /**
+   * Ascertain the remaining time until the next transition of this clock
+   * signal.
+   *
+   * @return Time in picoseconds.
+   */
+  uint32_t EdgeTimeDelta() const { return del_; }
+
+  /**
+   * Advance the state of this clock by the specified number of elapsed
+   * picoseconds, modifying the clock signal when a transition occurs.
+   *
+   * @return true iff a positive (rising) edge of this clock signal occurred.
+   */
+  bool PosEdgeAfterTime(uint32_t elapsed) {
+    // Transition occurred?
+    if (elapsed < del_) {
+      del_ -= elapsed;
+      return false;
+    }
+
+    // We should not be advancing beyond a single clock transition or the
+    // scheduling failed.
+    assert(elapsed == del_);
+
+    // Remember and invert the state of the controlled signal.
+    bool was_lo = !*sig_clk_;
+    *sig_clk_ = was_lo;
+    if (was_lo) {
+      // Starting hi interval.
+      del_ = (uint32_t)((int32_t)hi_interval_ + Randomize(hi_jitter_));
+    } else {
+      del_ = (uint32_t)((int32_t)lo_interval_ + Randomize(lo_jitter_));
+    }
+    return was_lo;
+  }
+
+ private:
+  int32_t Randomize(int32_t jitter) {
+    if (jitter) {
+      // lfsr_ cannot be zero (isolated state in sequence).
+      // Use (-50,+50%) of the specified jitter, uniform distribution.
+      jitter = (jitter * ((int32_t)lfsr_ - 128)) / 254;
+
+      // Simple LFSR for 8-bit sequences
+      lfsr_ = (uint8_t)((uint8_t)((lfsr_) << 1) ^
+                        ((((lfsr_) >> 1) ^ ((lfsr_) >> 2) ^ ((lfsr_) >> 3) ^
+                          ((lfsr_) >> 7)) &
+                         1U));
+    }
+    return jitter;
+  }
+
+  // Controlled signal in Verilated top level.
+  CData *sig_clk_;
+
+  // All times are in picoseconds.
+  uint32_t hi_interval_;  // Mean time for which the clock is high
+  uint32_t lo_interval_;  // Mean time low
+  uint32_t hi_jitter_;    // Amount by which the hi interval may jitter
+  uint32_t lo_jitter_;
+
+  // Randomization using LFSR.
+  uint8_t lfsr_;
+
+  // Time remaining until transition.
+  uint32_t del_;
+};
+
+#endif  // OPENTITAN_HW_DV_VERILATOR_SIMUTIL_VERILATOR_CPP_VERILATOR_SIM_CLOCK_H_

--- a/vendor/lowrisc_ibex/vendor/lowrisc_ip/dv/verilator/simutil_verilator/simutil_verilator.core
+++ b/vendor/lowrisc_ibex/vendor/lowrisc_ip/dv/verilator/simutil_verilator/simutil_verilator.core
@@ -12,6 +12,7 @@ filesets:
       - cpp/verilated_toplevel.cc
       - cpp/verilator_sim_ctrl.h: { is_include_file: true }
       - cpp/verilated_toplevel.h: { is_include_file: true }
+      - cpp/verilator_sim_clock.h: { is_include_file: true }
       - cpp/sim_ctrl_extension.h: { is_include_file: true }
     file_type: cppSource
 

--- a/vendor/patches/lowrisc_ibex/0001-Add-Clock-Support.patch
+++ b/vendor/patches/lowrisc_ibex/0001-Add-Clock-Support.patch
@@ -1,0 +1,378 @@
+diff --git a/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_clock.h b/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_clock.h
+new file mode 100644
+index 00000000..d4b546fb
+--- /dev/null
++++ b/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_clock.h
+@@ -0,0 +1,111 @@
++// Copyright lowRISC contributors.
++// Licensed under the Apache License, Version 2.0, see LICENSE for details.
++// SPDX-License-Identifier: Apache-2.0
++
++#ifndef OPENTITAN_HW_DV_VERILATOR_SIMUTIL_VERILATOR_CPP_VERILATOR_SIM_CLOCK_H_
++#define OPENTITAN_HW_DV_VERILATOR_SIMUTIL_VERILATOR_CPP_VERILATOR_SIM_CLOCK_H_
++#include <cassert>
++#include <cstdint>
++
++#include "verilated_toplevel.h"
++
++/**
++ * Clock signal in Verilated top level.
++ */
++class VerilatorSimClock {
++ public:
++  /**
++   * Initialize a clock signal with its properties.
++   * All time parameters are specified in picoseconds for accuracy.
++   *
++   * @param sig_clk Signal in the Verilated top level object.
++   * @param hi_interval Time interval for the 'hi' phase of the clock, in ps.
++   * @param lo_interval Time interval for the 'lo' phase of the clock, in ps.
++   * @param init_offset Time interval until the first transition of the clock, in ps.
++   * @param hi_jitter Amount by which 'hi_interval' may vary, in picoseconds.
++   * @param lo_jitter Amount by which 'lo_interval' may vary, in picoseconds.
++   */
++  VerilatorSimClock(CData *sig_clk, uint32_t hi_interval, uint32_t lo_interval,
++                    uint32_t init_offset = 0u, uint32_t hi_jitter = 0u, uint32_t lo_jitter = 0u)
++      : sig_clk_(sig_clk),
++        hi_interval_(hi_interval),
++        lo_interval_(lo_interval),
++        hi_jitter_(hi_jitter),
++        lo_jitter_(lo_jitter),
++        lfsr_(1u),
++        del_(init_offset) {
++    // Each clock interval (hi/lo) is permitted to vary in the range
++    // (-jitter/2, +jitter/2)
++    assert(hi_jitter < hi_interval && lo_jitter < lo_interval);
++  }
++
++  /**
++   * Ascertain the remaining time until the next transition of this clock
++   * signal.
++   *
++   * @return Time in picoseconds.
++   */
++  uint32_t EdgeTimeDelta() const { return del_; }
++
++  /**
++   * Advance the state of this clock by the specified number of elapsed
++   * picoseconds, modifying the clock signal when a transition occurs.
++   *
++   * @return true iff a positive (rising) edge of this clock signal occurred.
++   */
++  bool PosEdgeAfterTime(uint32_t elapsed) {
++    // Transition occurred?
++    if (elapsed < del_) {
++      del_ -= elapsed;
++      return false;
++    }
++
++    // We should not be advancing beyond a single clock transition or the
++    // scheduling failed.
++    assert(elapsed == del_);
++
++    // Remember and invert the state of the controlled signal.
++    bool was_lo = !*sig_clk_;
++    *sig_clk_ = was_lo;
++    if (was_lo) {
++      // Starting hi interval.
++      del_ = (uint32_t)((int32_t)hi_interval_ + Randomize(hi_jitter_));
++    } else {
++      del_ = (uint32_t)((int32_t)lo_interval_ + Randomize(lo_jitter_));
++    }
++    return was_lo;
++  }
++
++ private:
++  int32_t Randomize(int32_t jitter) {
++    if (jitter) {
++      // lfsr_ cannot be zero (isolated state in sequence).
++      // Use (-50,+50%) of the specified jitter, uniform distribution.
++      jitter = (jitter * ((int32_t)lfsr_ - 128)) / 254;
++
++      // Simple LFSR for 8-bit sequences
++      lfsr_ = (uint8_t)((uint8_t)((lfsr_) << 1) ^
++                        ((((lfsr_) >> 1) ^ ((lfsr_) >> 2) ^ ((lfsr_) >> 3) ^
++                          ((lfsr_) >> 7)) &
++                         1U));
++    }
++    return jitter;
++  }
++
++  // Controlled signal in Verilated top level.
++  CData *sig_clk_;
++
++  // All times are in picoseconds.
++  uint32_t hi_interval_;  // Mean time for which the clock is high
++  uint32_t lo_interval_;  // Mean time low
++  uint32_t hi_jitter_;    // Amount by which the hi interval may jitter
++  uint32_t lo_jitter_;
++
++  // Randomization using LFSR.
++  uint8_t lfsr_;
++
++  // Time remaining until transition.
++  uint32_t del_;
++};
++
++#endif  // OPENTITAN_HW_DV_VERILATOR_SIMUTIL_VERILATOR_CPP_VERILATOR_SIM_CLOCK_H_
+diff --git a/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc b/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+index d92b1b36..3128cbaa 100644
+--- a/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
++++ b/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+@@ -7,6 +7,7 @@
+ #include <getopt.h>
+ #include <iostream>
+ #include <signal.h>
++#include <stdlib.h>
+ #include <sys/stat.h>
+ #include <verilated.h>
+ 
+@@ -20,7 +21,7 @@
+  *
+  * Called by $time in Verilog, converts to double, to match what SystemC does
+  */
+-double sc_time_stamp() { return VerilatorSimCtrl::GetInstance().GetTime(); }
++double sc_time_stamp() { return VerilatorSimCtrl::GetInstance().GetSimTime(); }
+ 
+ #ifdef VL_USER_STOP
+ /**
+@@ -39,10 +40,9 @@ VerilatorSimCtrl &VerilatorSimCtrl::GetInstance() {
+   return instance;
+ }
+ 
+-void VerilatorSimCtrl::SetTop(VerilatedToplevel *top, CData *sig_clk,
+-                              CData *sig_rst, VerilatorSimCtrlFlags flags) {
++void VerilatorSimCtrl::SetTop(VerilatedToplevel *top, CData *sig_rst,
++                              VerilatorSimCtrlFlags flags) {
+   top_ = top;
+-  sig_clk_ = sig_clk;
+   sig_rst_ = sig_rst;
+   flags_ = flags;
+ }
+@@ -228,7 +228,8 @@ void VerilatorSimCtrl::RegisterExtension(SimCtrlExtension *ext) {
+ 
+ VerilatorSimCtrl::VerilatorSimCtrl()
+     : top_(nullptr),
+-      time_(0),
++      cycle_(0),
++      sim_time_(0),
+ #ifdef VM_TRACE_FMT_FST
+       trace_file_path_("sim.fst"),
+ #else
+@@ -247,20 +248,39 @@ VerilatorSimCtrl::VerilatorSimCtrl()
+ }
+ 
+ void VerilatorSimCtrl::RegisterSignalHandler() {
++  const int sigTypes[] = {
++    SIGINT, SIGABRT, SIGFPE, SIGUSR1, SIGILL
++  };
+   struct sigaction sigIntHandler;
+ 
+   sigIntHandler.sa_handler = SignalHandler;
+   sigemptyset(&sigIntHandler.sa_mask);
+   sigIntHandler.sa_flags = 0;
+ 
+-  sigaction(SIGINT, &sigIntHandler, NULL);
+-  sigaction(SIGUSR1, &sigIntHandler, NULL);
++  for (int i = 0; i < sizeof(sigTypes)/sizeof(sigTypes[0]); ++i) {
++    sigaction(sigTypes[i], &sigIntHandler, NULL);
++  }
+ }
+ 
+ void VerilatorSimCtrl::SignalHandler(int sig) {
+   VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
+ 
+   switch (sig) {
++    // Abort (eg. assertion failure in DPI model)
++    case SIGABRT:
++    // Exceptions
++    case SIGFPE:
++    case SIGILL:
++    case SIGSEGV:
++      // Try to ensure that traces are up to date
++      if (simctrl.TracingEverEnabled()) {
++        simctrl.tracer_.close();
++      }
++
++      simctrl.RequestStop(true);
++      exit(1);
++      break;
++
+     case SIGINT:
+       simctrl.RequestStop(true);
+       break;
+@@ -310,13 +330,15 @@ bool VerilatorSimCtrl::TraceOff() {
+ }
+ 
+ void VerilatorSimCtrl::PrintStatistics() const {
+-  double speed_hz = time_ / 2 / (GetExecutionTimeMs() / 1000.0);
++  // Count of cycles of the main system clock.
++  uint64_t cycles = GetCycles();
++  double speed_hz = cycles / (GetExecutionTimeMs() / 1000.0);
+   double speed_khz = speed_hz / 1000.0;
+ 
+   std::cout << std::endl
+             << "Simulation statistics" << std::endl
+             << "=====================" << std::endl
+-            << "Executed cycles:  " << std::dec << time_ / 2 << std::endl
++            << "Executed cycles:  " << std::dec << cycles << std::endl
+             << "Wallclock time:   " << GetExecutionTimeMs() / 1000.0 << " s"
+             << std::endl
+             << "Simulation speed: " << speed_hz << " cycles/s "
+@@ -354,27 +376,56 @@ void VerilatorSimCtrl::Run() {
+   unsigned long start_reset_cycle_ = initial_reset_delay_cycles_;
+   unsigned long end_reset_cycle_ = start_reset_cycle_ + reset_duration_cycles_;
+ 
+-  while (1) {
+-    unsigned long cycle_ = time_ / 2;
++  // Initialize the count of system clock cycles.
++  cycle_ = 0u;
+ 
++  while (1) {
+     if (cycle_ == start_reset_cycle_) {
+       SetReset();
+     } else if (cycle_ == end_reset_cycle_) {
+       UnsetReset();
+     }
+ 
+-    *sig_clk_ = !*sig_clk_;
++    // Determine the maximal amount of simulation time that may elapse
++    // before another clock edge (positive or negative) occurs.
++    uint32_t time_del = std::numeric_limits<uint32_t>::max();
++    for (auto it = clks_.begin(); it != clks_.end(); ++it) {
++      uint32_t next = (*it).EdgeTimeDelta();
++      if (time_del > next) {
++        // This clock has an earlier transition; we must not advance the
++        // simulation beyond any clock edge, because we cannot know to which
++        // edge(s) the design is sensitive.
++        time_del = next;
++      }
++    }
++
++    // Note: the system clock (used to report the overall simulation performance)
++    // must be the first clock in the list.
++    bool sys_clk = true;
++    bool sys_clk_rise = false;
++    // Handle all clock transitions at this time.
++    for (auto it = clks_.begin(); it != clks_.end(); ++it) {
++      bool pos_edge = (*it).PosEdgeAfterTime(time_del);
++      if (sys_clk) {
++        sys_clk_rise = pos_edge;
++      }
++      sys_clk = false;
++    }
++
++    sim_time_ += time_del;
+ 
+     // Call all extension on-clock methods
+-    if (*sig_clk_) {
++    if (sys_clk_rise) {
++      cycle_++;
++
+       for (auto it = extension_array_.begin(); it != extension_array_.end();
+            ++it) {
+-        (*it)->OnClock(time_);
++        // The value passed is the number of half-clock periods.
++        (*it)->OnClock(cycle_ * 2u);
+       }
+     }
+ 
+     top_->eval();
+-    time_++;
+ 
+     Trace();
+ 
+@@ -388,7 +439,7 @@ void VerilatorSimCtrl::Run() {
+                 << std::endl;
+       break;
+     }
+-    if (term_after_cycles_ && (time_ / 2 >= term_after_cycles_)) {
++    if (term_after_cycles_ && cycle_ >= term_after_cycles_) {
+       std::cout << "Simulation timeout of " << term_after_cycles_
+                 << " cycles reached, shutting down simulation." << std::endl;
+       break;
+@@ -466,5 +517,5 @@ void VerilatorSimCtrl::Trace() {
+               << std::endl;
+   }
+ 
+-  tracer_.dump(GetTime());
++  tracer_.dump(GetSimTime());
+ }
+diff --git a/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h b/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
+index 9e60d1ab..dc3e1db3 100644
+--- a/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
++++ b/vendor/lowrisc_ip/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.h
+@@ -10,7 +10,7 @@
+ #include <vector>
+ 
+ #include "sim_ctrl_extension.h"
+-#include "verilated_toplevel.h"
++#include "verilator_sim_clock.h"
+ 
+ enum VerilatorSimCtrlFlags {
+   Defaults = 0,
+@@ -35,8 +35,20 @@ class VerilatorSimCtrl {
+   /**
+    * Set the top-level design
+    */
+-  void SetTop(VerilatedToplevel *top, CData *sig_clk, CData *sig_rst,
++  void SetTop(VerilatedToplevel *top, CData *sig_rst,
+               VerilatorSimCtrlFlags flags = Defaults);
++  /**
++   * Add a clock into the design.
++   *
++   * @param sig_clk Signal in the Verilated top level object.
++   * @param hi_interval Time interval for the 'hi' phase of the clock, in
++   * picoseconds.
++   * @param lo_interval Time interval for the 'lo' phase of the clock, in
++   * picoseconds.
++   * @param hi_jitter Amount by which 'hi_interval' may vary, in picoseconds.
++   * @param lo_jitter Amount by which 'lo_interval' may vary, in picoseconds.
++   */
++  void AddClock(const VerilatorSimClock &clk) { clks_.push_back(clk); }
+ 
+   /**
+    * Setup and run the simulation (all in one)
+@@ -117,16 +129,26 @@ class VerilatorSimCtrl {
+   void RegisterExtension(SimCtrlExtension *ext);
+ 
+   /**
+-   * Get the current time in ticks
++   * Get the current cycle count of the main system clock.
+    */
+-  unsigned long GetTime() const { return time_; }
++  uint64_t GetCycles() const { return cycle_; }
++
++  /**
++   * Get the current time in picoseconds.
++   */
++  uint64_t GetSimTime() const { return sim_time_; }
+ 
+  private:
+   VerilatedToplevel *top_;
+-  CData *sig_clk_;
++  // List of clocks driving the simulation test bench.
++  std::vector<VerilatorSimClock> clks_;
+   CData *sig_rst_;
+   VerilatorSimCtrlFlags flags_;
+-  unsigned long time_;
++  // Number of cycles of the main system clock.
++  uint64_t cycle_;
++  // Elapsed simulation time, in picoseconds.
++  uint64_t sim_time_;
++
+   std::string trace_file_path_;
+   bool tracing_enabled_;
+   bool tracing_enabled_changed_;
+diff --git a/vendor/lowrisc_ip/dv/verilator/simutil_verilator/simutil_verilator.core b/vendor/lowrisc_ip/dv/verilator/simutil_verilator/simutil_verilator.core
+index d14327ae..b69fc207 100644
+--- a/vendor/lowrisc_ip/dv/verilator/simutil_verilator/simutil_verilator.core
++++ b/vendor/lowrisc_ip/dv/verilator/simutil_verilator/simutil_verilator.core
+@@ -12,6 +12,7 @@ filesets:
+       - cpp/verilated_toplevel.cc
+       - cpp/verilator_sim_ctrl.h: { is_include_file: true }
+       - cpp/verilated_toplevel.h: { is_include_file: true }
++      - cpp/verilator_sim_clock.h: { is_include_file: true }
+       - cpp/sim_ctrl_extension.h: { is_include_file: true }
+     file_type: cppSource
+ 


### PR DESCRIPTION
This PR permits the HyperBus Memory Controller (a.k.a HyperRAM) to be used in simulation with a clocking scheme and timing that much more closely models the HyperRAM activity on the FPGA board. More importantly it makes possible the development and testing in simulation of improved HyperRAM access.

 - Modify the simulator control test bench to support multiple clocks of different frequencies and phases; the HBMC requires three different clock signals, having specific phase relationships, and all of a different frequency from the Sonata system clock. This change also permits better modelling of the USB connectivity.
 - Introduce build switches `USE_SEPARATED_CLOCKS` and `USE_HYPERRAM_SIM_MODEL` which must be presented to both the C++ test bench and the SystemVerilog design; see `sonata.core`.
 - Model the Xilinx primitives used in the HBMC implementation. These models are not complete but work well enough for the vendored HBMC design to be simulated without any source modification.
 - Add a model of the HyperRAM W956D8 device used on the Sonata FPGA board.

The existing HyperRAM tests all pass with either the SRAM model (USE_HYPERRAM_SIM_MODEL) - as before - or the HBMC-controlled W956 simulation model. To test the latter the following patch may be applied, since the sonata.core file has been set up to preserve the earlier behaviour and favour faster simulations:
```
--- a/sonata.core
+++ b/sonata.core
@@ -173,7 +173,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_verilator -DUSE_HYPERRAM_SIM_MODEL"'
+          - '-CFLAGS "-Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_verilator -DUSE_SEPARATED_CLOCKS"'
           # Add "-DUSE_SEPARATED_CLOCKS" to CFLAGS for a more accurate simulation.
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
@@ -182,9 +182,8 @@ targets:
           # Verilator without increasing the unroll count (see Verilator#1266)
           - "--unroll-count 72"
     parameters:
-      - USE_SEPARATED_CLOCKS=false
+      - USE_SEPARATED_CLOCKS=true
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
-      - USE_HYPERRAM_SIM_MODEL=true
 
   lint:
     <<: *default_target
```