### PR TITLE
Increase HyperRAM clock frequency

### DIFF
--- a/dv/verilator/sonata_system.cc
+++ b/dv/verilator/sonata_system.cc
@@ -77,8 +77,8 @@ int SonataSystem::Setup(int argc, char **argv, bool &exit_app) {
   // Note: calculate the period of the higher frequency clock first because
   // the period of the 'hr' reference clock must be exactly 3 times longer
   // to maintain the phase relationship.
-  uint32_t hr3x_hperiod = (micro + 599u) / 600u;  // 300MHz cycle
-  uint32_t hr_hperiod = 3 * hr3x_hperiod;  // 100MHz cycle
+  uint32_t hr3x_hperiod = (micro + 1199u) / 1200u;  // 600MHz cycle
+  uint32_t hr_hperiod = 3 * hr3x_hperiod;  // 200MHz cycle
 
   // The HyperRAM requires a clock that is phase-shifted by 90 degress.
   uint32_t hr90p_offset = hr_hperiod / 2;

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -27,7 +27,7 @@ module top_verilator #(
   // System clock frequency.
   localparam int unsigned SysClkFreq = 40_000_000;
   // HyperRAM clock frequency.
-  localparam int unsigned HyperRAMClkFreq  = 100_000_000;
+  localparam int unsigned HyperRAMClkFreq  = 200_000_000;
   localparam int unsigned BaudRate   = 921_600;
   // Number of CHERI error LEDs.
   localparam int unsigned CheriErrWidth = 9;

--- a/rtl/fpga/clkgen_sonata.sv
+++ b/rtl/fpga/clkgen_sonata.sv
@@ -5,7 +5,7 @@
 module clkgen_sonata  #(
   // System Clock Frequency is parameterised, allowing it to be adjusted.
   parameter int unsigned SysClkFreq      =  50_000_000,
-  parameter int unsigned HyperRAMClkFreq = 100_000_000,
+  parameter int unsigned HyperRAMClkFreq = 200_000_000,
 
   // Frequency of IO_CLK input on the FPGA board.
   parameter int unsigned IOClkFreq       =  25_000_000

--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -218,7 +218,7 @@ module top_sonata
 
   // System clock frequency.
   parameter int unsigned SysClkFreq      =  40_000_000;
-  parameter int unsigned HyperRAMClkFreq = 100_000_000;
+  parameter int unsigned HyperRAMClkFreq = 200_000_000;
 
   parameter SRAMInitFile    = "";
 

--- a/rtl/ip/hyperram/rtl/hbmc_tl_top.sv
+++ b/rtl/ip/hyperram/rtl/hbmc_tl_top.sv
@@ -112,7 +112,7 @@ module hbmc_tl_top import tlul_pkg::*; #(
      into the slower clock domain, it can take 4 system clock cycles to collect the first word.
   */
   localparam int unsigned UDataWidth = top_pkg::TL_DW;
-  localparam int unsigned UFIFODepth = 1 << (Log2BurstLen - ABIT);
+  localparam int unsigned UFIFODepth = 2 << (Log2BurstLen - ABIT);
 
   /* The Downstream FIFO to the HyperRAM controller must be wide enough and deep enough to
    * accommodate all of the write data for a burst. The write coealescing logic in `hyperram_wrbuf`

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -12,7 +12,7 @@ module sonata_system
   parameter int unsigned CheriErrWidth   = 9,
   parameter string SRAMInitFile          = "",
   parameter int unsigned SysClkFreq      = 30_000_000,
-  parameter int unsigned HyperRAMClkFreq = 100_000_000
+  parameter int unsigned HyperRAMClkFreq = 200_000_000
 ) (
   // Main system clock and reset
   input logic                      clk_sys_i,


### PR DESCRIPTION
This PR builds on #439 and depends upon it.

Increase the HyperRAM clock frequency to 200MHz.
Adjust the clock frequency to 200MHz as per the W956 datasheet.
The OpenHBMC controller synthesises and operates fine at 200MHz, with the ISERDES operating at 600MHz. Presumably the lower frequency was set conservatively, but now that the HyperRAM interface is capable of bursting and buffering, performance does benefit from the higher frequency.

FPGA builds have been soak testing HyperRAM tests for over 12 hours without encountering any faults.