### PR TITLE
Revert HyperRAM clock frequency to 100MHz

### DIFF
--- a/dv/verilator/sonata_system.cc
+++ b/dv/verilator/sonata_system.cc
@@ -77,8 +77,8 @@ int SonataSystem::Setup(int argc, char **argv, bool &exit_app) {
   // Note: calculate the period of the higher frequency clock first because
   // the period of the 'hr' reference clock must be exactly 3 times longer
   // to maintain the phase relationship.
-  uint32_t hr3x_hperiod = (micro + 1199u) / 1200u;  // 600MHz cycle
-  uint32_t hr_hperiod = 3 * hr3x_hperiod;  // 200MHz cycle
+  uint32_t hr3x_hperiod = (micro + 599u) / 600u;  // 300MHz cycle
+  uint32_t hr_hperiod = 3 * hr3x_hperiod;  // 100MHz cycle
 
   // The HyperRAM requires a clock that is phase-shifted by 90 degress.
   uint32_t hr90p_offset = hr_hperiod / 2;

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -27,7 +27,7 @@ module top_verilator #(
   // System clock frequency.
   localparam int unsigned SysClkFreq = 40_000_000;
   // HyperRAM clock frequency.
-  localparam int unsigned HyperRAMClkFreq  = 200_000_000;
+  localparam int unsigned HyperRAMClkFreq  = 100_000_000;
   localparam int unsigned BaudRate   = 921_600;
   // Number of CHERI error LEDs.
   localparam int unsigned CheriErrWidth = 9;

--- a/rtl/fpga/clkgen_sonata.sv
+++ b/rtl/fpga/clkgen_sonata.sv
@@ -5,7 +5,7 @@
 module clkgen_sonata  #(
   // System Clock Frequency is parameterised, allowing it to be adjusted.
   parameter int unsigned SysClkFreq      =  50_000_000,
-  parameter int unsigned HyperRAMClkFreq = 200_000_000,
+  parameter int unsigned HyperRAMClkFreq = 100_000_000,
 
   // Frequency of IO_CLK input on the FPGA board.
   parameter int unsigned IOClkFreq       =  25_000_000

--- a/rtl/fpga/top_sonata.sv
+++ b/rtl/fpga/top_sonata.sv
@@ -218,7 +218,7 @@ module top_sonata
 
   // System clock frequency.
   parameter int unsigned SysClkFreq      =  40_000_000;
-  parameter int unsigned HyperRAMClkFreq = 200_000_000;
+  parameter int unsigned HyperRAMClkFreq = 100_000_000;
 
   parameter SRAMInitFile    = "";
 

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -12,7 +12,7 @@ module sonata_system
   parameter int unsigned CheriErrWidth   = 9,
   parameter string SRAMInitFile          = "",
   parameter int unsigned SysClkFreq      = 30_000_000,
-  parameter int unsigned HyperRAMClkFreq = 200_000_000
+  parameter int unsigned HyperRAMClkFreq = 100_000_000
 ) (
   // Main system clock and reset
   input logic                      clk_sys_i,


### PR DESCRIPTION
There is a suspected physical-level issue with recent builds which may be related to the increased clock frequency. Although that is uncertain, there are two other reasons to propose reverting the commit that increased the frequency:

1. There is a throughput mismatch between the HBMC read speed and the Sonata system with only a 32-bit Upstream FIFO. This could maybe lead to data loss because there is no braking/ backpressure mechanism. It was intended to widen `ufifo` to 64 bits but this has not yet been completed and proven.

2. The increased frequency offers a performance uplift of only about 10-16% with the current design. A greater boot should be possible later but that requires some re-architecting.
