### PR TITLE
Map the full HyperRAM

### DIFF
--- a/data/xbar_ifetch.hjson
+++ b/data/xbar_ifetch.hjson
@@ -37,7 +37,7 @@
       xbar:  false,
       addr_range: [{
         base_addr: "0x40000000",
-        size_byte: "0x00100000",
+        size_byte: "0x00800000",
       }],
     },
     { name:     "dbg_dev", // Debug module fetch interface

--- a/data/xbar_main.hjson
+++ b/data/xbar_main.hjson
@@ -48,7 +48,7 @@
       xbar:  false,
       addr_range: [{
         base_addr: "0x40000000",
-        size_byte: "0x00100000",
+        size_byte: "0x00800000",
       }],
     },
     { name:  "rev_tag", // Revocation tag memory

--- a/data/xbar_main.hjson.tpl
+++ b/data/xbar_main.hjson.tpl
@@ -48,7 +48,7 @@
       xbar:  false,
       addr_range: [{
         base_addr: "0x40000000",
-        size_byte: "0x00100000",
+        size_byte: "0x00800000",
       }],
     },
     { name:  "rev_tag", // Revocation tag memory

--- a/rtl/bus/tl_ifetch_pkg.sv
+++ b/rtl/bus/tl_ifetch_pkg.sv
@@ -11,7 +11,7 @@ package tl_ifetch_pkg;
   localparam logic [31:0] ADDR_SPACE_DBG_DEV  = 32'h b0000000;
 
   localparam logic [31:0] ADDR_MASK_SRAM     = 32'h 0003ffff;
-  localparam logic [31:0] ADDR_MASK_HYPERRAM = 32'h 000fffff;
+  localparam logic [31:0] ADDR_MASK_HYPERRAM = 32'h 007fffff;
   localparam logic [31:0] ADDR_MASK_DBG_DEV  = 32'h 00000fff;
 
   localparam int N_HOST   = 1;

--- a/rtl/bus/tl_main_pkg.sv
+++ b/rtl/bus/tl_main_pkg.sv
@@ -32,7 +32,7 @@ package tl_main_pkg;
   localparam logic [31:0] ADDR_SPACE_RV_PLIC     = 32'h 88000000;
 
   localparam logic [31:0] ADDR_MASK_SRAM        = 32'h 0001ffff;
-  localparam logic [31:0] ADDR_MASK_HYPERRAM    = 32'h 000fffff;
+  localparam logic [31:0] ADDR_MASK_HYPERRAM    = 32'h 007fffff;
   localparam logic [31:0] ADDR_MASK_REV_TAG     = 32'h 000007ff;
   localparam logic [31:0] ADDR_MASK_GPIO        = 32'h 00000fff;
   localparam logic [31:0] ADDR_MASK_PINMUX      = 32'h 00000fff;

--- a/rtl/ip/hyperram/rtl/hbmc_tl_port.sv
+++ b/rtl/ip/hyperram/rtl/hbmc_tl_port.sv
@@ -7,15 +7,23 @@
 // in the event that writes are supported.
 //
 // An instruction port need not support write operations and does not require tag bits.
+//
+// Tag bits may be supported for only part of the mapped HyperRAM address range, in which case
+// case an attempt to set a tag bit at an address that is outside that range will result in a
+// TL-UL error being returned and the write will not occur.
+
 module hbmc_tl_port import tlul_pkg::*; #(
+  // Width of HyperRAM address, in bits.
   parameter int unsigned HyperRAMAddrW = 20,
+  // Address width of the portion that can store capabilities, in bits.
+  parameter int unsigned HyperRAMTagAddrW = 18,
   // log2(burst length in bytes)
   parameter int unsigned Log2BurstLen = 5,  // 32-byte bursts.
   parameter int unsigned NumBufs = 4,
   parameter int unsigned PortIDWidth = 1,
   parameter int unsigned Log2MaxBufs = 2,
   parameter int unsigned SeqWidth = 6,
-  //
+
   // Does this port need to support TileLink write operations?
   parameter bit SupportWrites = 1,
   // Coalesce write transfers into burst writes to the HBMC?
@@ -25,57 +33,57 @@ module hbmc_tl_port import tlul_pkg::*; #(
   localparam int unsigned ABIT = $clog2(top_pkg::TL_DW / 8),
   localparam int unsigned BBIT = Log2BurstLen
 ) (
-  input                               clk_i,
-  input                               rst_ni,
+  input                                   clk_i,
+  input                                   rst_ni,
 
   // Constant indicating port number.
-  input             [PortIDWidth-1:0] portid_i,
+  input                 [PortIDWidth-1:0] portid_i,
 
   // TL-UL interface.
-  input  tl_h2d_t                     tl_i,
-  output tl_d2h_t                     tl_o,
+  input  tl_h2d_t                         tl_i,
+  output tl_d2h_t                         tl_o,
 
   // Write notification input.
-  input                               wr_notify_i,
-  input        [HyperRAMAddrW-1:ABIT] wr_notify_addr_i,
-  input         [top_pkg::TL_DBW-1:0] wr_notify_mask_i,
-  input          [top_pkg::TL_DW-1:0] wr_notify_data_i,
+  input                                   wr_notify_i,
+  input            [HyperRAMAddrW-1:ABIT] wr_notify_addr_i,
+  input             [top_pkg::TL_DBW-1:0] wr_notify_mask_i,
+  input              [top_pkg::TL_DW-1:0] wr_notify_data_i,
 
   // Write notification output.
-  output logic                        wr_notify_o,
-  output logic  [top_pkg::TL_DBW-1:0] wr_notify_mask_o,
-  output logic   [top_pkg::TL_DW-1:0] wr_notify_data_o,
-  output logic [HyperRAMAddrW-1:ABIT] wr_notify_addr_o,
+  output logic                            wr_notify_o,
+  output logic      [top_pkg::TL_DBW-1:0] wr_notify_mask_o,
+  output logic       [top_pkg::TL_DW-1:0] wr_notify_data_o,
+  output logic     [HyperRAMAddrW-1:ABIT] wr_notify_addr_o,
 
   // Command data to the HyperRAM controller; command, address and burst length
-  output logic                        cmd_req_o,
-  input                               cmd_wready_i,
-  output logic [HyperRAMAddrW-1:ABIT] cmd_mem_addr_o,
-  output logic  [Log2BurstLen-ABIT:0] cmd_word_cnt_o,
-  output logic                        cmd_wr_not_rd_o,
-  output logic                        cmd_wrap_not_incr_o,
-  output logic         [SeqWidth-1:0] cmd_seq_o,
+  output logic                            cmd_req_o,
+  input                                   cmd_wready_i,
+  output logic     [HyperRAMAddrW-1:ABIT] cmd_mem_addr_o,
+  output logic      [Log2BurstLen-ABIT:0] cmd_word_cnt_o,
+  output logic                            cmd_wr_not_rd_o,
+  output logic                            cmd_wrap_not_incr_o,
+  output logic             [SeqWidth-1:0] cmd_seq_o,
 
-  output logic                        tag_cmd_req,
-  output logic [HyperRAMAddrW-1:ABIT] tag_cmd_mem_addr,
-  output logic                        tag_cmd_wr_not_rd,
-  output                              tag_cmd_wcap,
+  output logic                            tag_cmd_req,
+  output logic  [HyperRAMTagAddrW-1:ABIT] tag_cmd_mem_addr,
+  output logic                            tag_cmd_wr_not_rd,
+  output                                  tag_cmd_wcap,
 
-  output logic                        dfifo_wr_ena_o,
-  input                               dfifo_wr_full_i,
-  output        [top_pkg::TL_DBW-1:0] dfifo_wr_strb_o,
-  output         [top_pkg::TL_DW-1:0] dfifo_wr_din_o,
+  output logic                            dfifo_wr_ena_o,
+  input                                   dfifo_wr_full_i,
+  output            [top_pkg::TL_DBW-1:0] dfifo_wr_strb_o,
+  output             [top_pkg::TL_DW-1:0] dfifo_wr_din_o,
 
   // Read data from the HyperRAM
-  output                              ufifo_rd_ena,
-  input                               ufifo_rd_empty,
-  input          [top_pkg::TL_DW-1:0] ufifo_rd_dout,
-  input                [SeqWidth-1:0] ufifo_rd_seq,
-  input                               ufifo_rd_last,
+  output                                  ufifo_rd_ena,
+  input                                   ufifo_rd_empty,
+  input              [top_pkg::TL_DW-1:0] ufifo_rd_dout,
+  input                    [SeqWidth-1:0] ufifo_rd_seq,
+  input                                   ufifo_rd_last,
 
   // Tag read data interface.
-  output                              tag_rdata_rready,
-  input                               tl_tag_bit
+  output                                  tag_rdata_rready,
+  input                                   tl_tag_bit
 );
 
 /*----------------------------------------------------------------------------------------------------------------------------*/
@@ -84,10 +92,15 @@ module hbmc_tl_port import tlul_pkg::*; #(
   logic tl_req_fifo_le1;
   logic wr_notify_match;
   logic dfifo_wr_full;
+  logic rdbuf_matches;  // Address matches within the read buffer.
+  logic rdbuf_valid;    // Valid data is available within the read buffer.
   logic cmd_wready;
   logic can_accept;
   logic rdbuf_hit;
   logic rdbuf_re;
+  logic wr_err;
+  logic wr_req;
+  logic rd_req;
   logic issue;
 
   // We can accept an incoming TileLink transaction when we've got space in the hyperram, tag
@@ -106,10 +119,22 @@ module hbmc_tl_port import tlul_pkg::*; #(
                      (tl_i.a_opcode == Get || ~dfifo_wr_full) &
                      ~(wr_notify_i & wr_notify_match);
 
+  // Return an error response for any capability write to an address that cannot support tags.
+  wire untagged_addr = |(tl_i.a_address[HyperRAMAddrW:0] >> HyperRAMTagAddrW) &
+                         tl_i.a_user.capability;
+
 /*----------------------------------------------------------------------------------------------------------------------------*/
 
-  wire rd_req = tl_i.a_valid & (tl_i.a_opcode == Get);
-  wire wr_req = tl_i.a_valid & (tl_i.a_opcode == PutFullData || tl_i.a_opcode == PutPartialData);
+  // Valid read request?
+  assign rd_req = tl_i.a_valid & (tl_i.a_opcode == Get);
+  // Valid write request?
+  assign wr_req = tl_i.a_valid & (tl_i.a_opcode == PutFullData || tl_i.a_opcode == PutPartialData) &
+                 (SupportWrites & !untagged_addr);
+
+/*----------------------------------------------------------------------------------------------------------------------------*/
+  // Invalid write request?
+  assign wr_err = tl_i.a_valid & (tl_i.a_opcode == PutFullData || tl_i.a_opcode == PutPartialData) &
+                 (untagged_addr | !SupportWrites);
 
 /*----------------------------------------------------------------------------------------------------------------------------*/
   if (SupportWrites) begin
@@ -138,10 +163,8 @@ module hbmc_tl_port import tlul_pkg::*; #(
 
 /*----------------------------------------------------------------------------------------------------------------------------*/
 
-  logic rdbuf_matches;  // Address matches within the read buffer.
-  logic rdbuf_valid;    // Valid data is available within the read buffer.
   logic [SeqWidth-1:0] rdbuf_seq;  // Sequence number of read buffer contents.
-  logic [top_pkg::TL_DW-1:0]  rdbuf_dout;
+  logic [top_pkg::TL_DW-1:0] rdbuf_dout;
 
   // Invalidate the read buffer contents when a write occurs.
   //
@@ -219,12 +242,21 @@ module hbmc_tl_port import tlul_pkg::*; #(
   localparam int unsigned TL_REQ_FIFO_DEPTH = 4;
   localparam int unsigned TLReqFifoDepthW = prim_util_pkg::vbits(TL_REQ_FIFO_DEPTH+1);
 
-  // Metadata from inbound TileLink transactions that needs to be saved to produce the response
+  // Verdict on the TL-UL request.
+  typedef enum logic [1:0] {
+    TLRspRdBuf,   // Return buffered read data.
+    TLRspRdFetch, // Fetching read data from HBMC.
+    TLRspWrOk,    // Valid write.
+    TLRspWrErr    // Return error on write.
+  } tl_rsp_type_e;
+
+  // Description of a queued TL-UL request-response.
   typedef struct packed {
+    // Metadata from inbound TileLink transactions that needs to be saved to produce the response.
     logic [top_pkg::TL_AIW-1:0] tl_source;
     logic [top_pkg::TL_SZW-1:0] tl_size;
-    logic                       cmd_fetch;
-    logic                       cmd_wr_not_rd;
+    // Response to be returned.
+    tl_rsp_type_e               rsp_type;
   } tl_req_info_t;
 
   tl_req_info_t tl_req_fifo_wdata, tl_req_fifo_rdata;
@@ -242,7 +274,7 @@ module hbmc_tl_port import tlul_pkg::*; #(
   // To be a contender in the arbitration among all ports, we need to express our intention
   // to write into the command buffer.
   wire cmd_req = tl_i.a_valid && tl_req_fifo_wready && !rdbuf_hit &&
-                (tl_i.a_opcode == Get || ~dfifo_wr_full);
+                (tl_i.a_opcode == Get || (!dfifo_wr_full & !wr_err));
 
   assign issue = tl_i.a_valid & can_accept;
 
@@ -257,26 +289,24 @@ module hbmc_tl_port import tlul_pkg::*; #(
 
     if (issue) begin
       // Write to the relevant FIFOs and indicate ready on TileLink A channel
-      tag_cmd_req        = 1'b1;
+      // - no tag request if the write was rejected.
+      tag_cmd_req        = !wr_err;
       tl_req_fifo_wvalid = 1'b1;
-
-      if (tl_i.a_opcode != Get) begin
-        dfifo_wr_ena      = 1'b1;
-      end
+      // Write into the downstream FIFO only for a valid write.
+      dfifo_wr_ena       = wr_req;
     end
   end
 
   assign tag_cmd_wr_not_rd = cmd_wr_not_rd;
-  assign tag_cmd_mem_addr = tl_i.a_address[HyperRAMAddrW-1:ABIT];
+  assign tag_cmd_mem_addr = tl_i.a_address[HyperRAMTagAddrW-1:ABIT];
 
-  wire tl_cmd_fetch = ~(rd_req & rdbuf_valid);
-  wire tl_cmd_wr_not_rd = (tl_i.a_opcode != Get);
-
+  // Decide on the type of response to be sent; encoded using an enumeration to reduce FIFO width.
+  tl_rsp_type_e tl_cmd_rsp = (rd_req ? (rdbuf_valid ? TLRspRdBuf : TLRspRdFetch)
+                                     : (wr_err      ? TLRspWrErr : TLRspWrOk));
   assign tl_req_fifo_wdata = '{
     tl_source     : tl_i.a_source,
     tl_size       : tl_i.a_size,
-    cmd_fetch     : tl_cmd_fetch,
-    cmd_wr_not_rd : tl_cmd_wr_not_rd
+    rsp_type      : tl_cmd_rsp
   };
 
   // We decant the read data from the 'Upstream FIFO' into the read buffer as soon as possible,
@@ -300,6 +330,11 @@ module hbmc_tl_port import tlul_pkg::*; #(
   logic [top_pkg::TL_DW-1:0] ufifo_dout_first;
   assign ufifo_dout_first = ufifo_rd_dout[top_pkg::TL_DW-1:0];
 
+  // Decode control signals from the response type.
+  wire tl_rsp_wr_not_rd   = (tl_req_fifo_rdata.rsp_type == TLRspWrOk ||
+                             tl_req_fifo_rdata.rsp_type == TLRspWrErr);
+  wire tl_rsp_rd_buffered = (tl_req_fifo_rdata.rsp_type == TLRspRdBuf);
+
   // If the data from the read buffer is not accepted immediately by the host we must register it
   // to prevent it being invalidated by another read.
   logic rdata_valid_q;
@@ -311,9 +346,9 @@ module hbmc_tl_port import tlul_pkg::*; #(
       if (tl_i.d_ready) rdata_valid_q <= 1'b0;  // Response sent.
       else begin
         // Capture read data and keep it stable until it is accepted by the host.
-        rdata_valid_q <= !tl_req_fifo_rdata.cmd_wr_not_rd;
+        rdata_valid_q <= !tl_rsp_wr_not_rd;
         if (!rdata_valid_q) begin
-          rdata_q <= tl_req_fifo_rdata.cmd_fetch ? ufifo_dout_first : rdbuf_dout;
+          rdata_q <= tl_rsp_rd_buffered ? rdbuf_dout : ufifo_dout_first;
         end
       end
     end
@@ -328,23 +363,23 @@ module hbmc_tl_port import tlul_pkg::*; #(
     tl_o_int           = '0;
     if (tl_req_fifo_rvalid) begin
       // We have an incoming request that needs a response
-      if (tl_req_fifo_rdata.cmd_wr_not_rd) begin
+      if (tl_rsp_wr_not_rd) begin
         // If it's a write then return an immediate response (early response is reasonable as any
         // read that could observe the memory cannot occur until the write has actually happened)
         tl_o_int.d_valid   = 1'b1;
       end else begin
         // Otherwise wait until we have the first word of data to return.
         tl_o_int.d_valid   = |{ufifo_rd_ena & ~ufifo_rd_bursting,  // Initial word of burst read.
-                               ~tl_req_fifo_rdata.cmd_fetch,  // From read buffer.
+                               tl_rsp_rd_buffered,  // From read buffer.
                                rdata_valid_q};  // Holding read data stable until accepted.
       end
     end
-
-    tl_o_int.d_opcode          = tl_req_fifo_rdata.cmd_wr_not_rd ? AccessAck : AccessAckData;
+    tl_o_int.d_error           = (tl_req_fifo_rdata.rsp_type == TLRspWrErr);
+    tl_o_int.d_opcode          = tl_rsp_wr_not_rd ? AccessAck : AccessAckData;
     tl_o_int.d_size            = tl_req_fifo_rdata.tl_size;
     tl_o_int.d_source          = tl_req_fifo_rdata.tl_source;
     tl_o_int.d_data            = rdata_valid_q ? rdata_q :
-                                (tl_req_fifo_rdata.cmd_fetch ? ufifo_dout_first : rdbuf_dout);
+                                (tl_rsp_rd_buffered ? rdbuf_dout : ufifo_dout_first);
     tl_o_int.d_user.capability = tl_tag_bit;
     tl_o_int.a_ready           = issue;
   end
@@ -354,7 +389,7 @@ module hbmc_tl_port import tlul_pkg::*; #(
   assign tl_req_fifo_rready = tl_o_int.d_valid & tl_i.d_ready;
 
   // Discard the tag read data once the _read_ data is accepted.
-  assign tag_rdata_rready = tl_o_int.d_valid & tl_i.d_ready & ~tl_req_fifo_rdata.cmd_wr_not_rd;
+  assign tag_rdata_rready = tl_o_int.d_valid & tl_i.d_ready & ~tl_rsp_wr_not_rd;
 
   // Generate integrity for outgoing response.
   tlul_rsp_intg_gen #(

--- a/rtl/ip/hyperram/rtl/hbmc_tl_top.sv
+++ b/rtl/ip/hyperram/rtl/hbmc_tl_top.sv
@@ -60,7 +60,10 @@ module hbmc_tl_top import tlul_pkg::*; #(
   parameter [4:0]   C_DQ0_IDELAY_TAPS_VALUE  = 0,
 
   parameter int unsigned NumPorts = 2,
-  parameter integer HyperRAMSize = 1024 * 1024 // 1 MiB
+  // Mapped size of the HyperRAM, in bytes.
+  parameter int unsigned HyperRAMSize = 8 * 1024 * 1024, // 8 MiB
+  // Mapped portion of the HyperRAM that can store capabilities, in bytes.
+  parameter int unsigned HyperRAMTagSize = 2 * 1024 * 1024 // 2 MiB
 )
 (
   input  clk_i,
@@ -97,8 +100,10 @@ module hbmc_tl_top import tlul_pkg::*; #(
   // bits to identify the buffer number, and a further bit for the port number of
   // the requester.
   localparam int unsigned SeqWidth = PortIDWidth + Log2MaxBufs + 3;
-
+  // Width of HyperRAM address, in bits.
   localparam int unsigned HyperRAMAddrW = $clog2(HyperRAMSize);
+  // Address width of the portion that can store capabilities, in bits.
+  localparam int unsigned HyperRAMTagAddrW = $clog2(HyperRAMTagSize);
   // LSB of word address.
   localparam int unsigned ABIT = $clog2(top_pkg::TL_DW / 8);
   // Use 32-byte bursts for performance, whilst reducing the penalty of wasted burst reads.
@@ -256,7 +261,7 @@ module hbmc_tl_top import tlul_pkg::*; #(
   logic [NumPorts-1:0]                    dfifo_all_wr_full;
 
   logic [NumPorts-1:0] tag_all_cmd_req;
-  logic [NumPorts-1:0][HyperRAMAddrW-1:ABIT] tag_all_cmd_mem_addr;
+  logic [NumPorts-1:0][HyperRAMTagAddrW-1:ABIT] tag_all_cmd_mem_addr;
   logic [NumPorts-1:0] tag_all_cmd_wr_not_rd;
   logic [NumPorts-1:0] tag_all_rdata_rready;
 
@@ -290,13 +295,14 @@ module hbmc_tl_top import tlul_pkg::*; #(
 
   for (genvar p = 0; p < NumPorts; p++) begin : gen_ports
     hbmc_tl_port #(
-      .HyperRAMAddrW  (HyperRAMAddrW),
-      .Log2BurstLen   (Log2BurstLen),
-      .NumBufs        (MaxBufs),
-      .PortIDWidth    (PortIDWidth),
-      .Log2MaxBufs    (Log2MaxBufs),
-      .SeqWidth       (SeqWidth),
-      .SupportWrites  (p == PortD)  // Only the data port supports writing.
+      .HyperRAMAddrW    (HyperRAMAddrW),
+      .HyperRAMTagAddrW (HyperRAMTagAddrW),
+      .Log2BurstLen     (Log2BurstLen),
+      .NumBufs          (MaxBufs),
+      .PortIDWidth      (PortIDWidth),
+      .Log2MaxBufs      (Log2MaxBufs),
+      .SeqWidth         (SeqWidth),
+      .SupportWrites    (p == PortD)  // Only the data port supports writing.
     ) u_port(
       .clk_i              (clk_i),
       .rst_ni             (rst_ni),
@@ -574,8 +580,8 @@ module hbmc_tl_top import tlul_pkg::*; #(
   // Command FIFO provides reads and writes from tilelink requests. Writes just happen without any
   // response and reads writes to rdata_fifo to be picked up by the tilelink response.
 
-  // 1 tag bit per 64 bits so divide HyperRAMSize by 8
-  localparam TAG_ADDR_W = $clog2(HyperRAMSize) - 3;
+  // 1 tag bit per 64 bits so divide HyperRAMTagSize by 8
+  localparam TAG_ADDR_W = HyperRAMTagAddrW - 3;
   localparam TAG_FIFO_DEPTH = 4;
 
   typedef struct packed {
@@ -590,7 +596,7 @@ module hbmc_tl_top import tlul_pkg::*; #(
 
   // Only the Data port requires capability tags.
   tag_cmd_t tag_cmd;
-  assign tag_cmd.addr  = tag_all_cmd_mem_addr[PortD][HyperRAMAddrW-1:ABIT+1];
+  assign tag_cmd.addr  = tag_all_cmd_mem_addr[PortD][HyperRAMTagAddrW-1:ABIT+1];
   assign tag_cmd.write = tag_all_cmd_wr_not_rd[PortD];
   assign tag_cmd.wdata = tag_all_cmd_wcap[PortD];
 

--- a/rtl/ip/hyperram/rtl/hyperram.sv
+++ b/rtl/ip/hyperram/rtl/hyperram.sv
@@ -9,8 +9,11 @@
 // particular require Xilinx encrypted IP models).
 
 module hyperram import tlul_pkg::*; #(
-  parameter HyperRAMClkFreq = 200_000_000,
-  parameter HyperRAMSize    = 1024 * 1024,
+  parameter int unsigned HyperRAMClkFreq = 200_000_000,
+  // Mapped size of the HyperRAM, in bytes.
+  parameter int unsigned HyperRAMSize    = 8 * 1024 * 1024, // 8 MiB
+  // Mapped portion of the HyperRAM that can store capabilities, in bytes.
+  parameter int unsigned HyperRAMTagSize = 2 * 1024 * 1024, // 2 MiB
   // Number of access ports.
   parameter int unsigned NumPorts = 2
 ) (
@@ -120,7 +123,8 @@ module hyperram import tlul_pkg::*; #(
     .C_DQ0_IDELAY_TAPS_VALUE(0),
     .C_ISERDES_CLOCKING_MODE(0),
     .NumPorts(NumPorts),
-    .HyperRAMSize(HyperRAMSize)
+    .HyperRAMSize(HyperRAMSize),
+    .HyperRAMTagSize(HyperRAMTagSize)
   ) u_hbmc_tl_top (
     .clk_i(clk_i),
     .rst_ni(rst_ni),

--- a/rtl/system/sonata_system.sv
+++ b/rtl/system/sonata_system.sv
@@ -116,20 +116,21 @@ module sonata_system
   // Signals, types and parameters for system. //
   ///////////////////////////////////////////////
 
-  localparam int unsigned MemSize       = 128 * 1024; // 128 KiB
-  localparam int unsigned SRAMAddrWidth = $clog2(MemSize);
-  localparam int unsigned HyperRAMSize  = 1024 * 1024; // 1 MiB
-  localparam int unsigned PwmCtrSize    = 8;
-  localparam int unsigned BusAddrWidth  = 32;
-  localparam int unsigned BusByteEnable = 4;
-  localparam int unsigned BusDataWidth  = 32;
-  localparam int unsigned DRegAddrWidth = 12; // Debug module uses 12 bits of addressing.
-  localparam int unsigned TRegAddrWidth = 16; // Timer uses more address bits.
-  localparam int unsigned FixedSpiNum   = 2; // Number of SPI devices that don't pass through the pinmux
-  localparam int unsigned TotalSpiNum   = SPI_NUM + FixedSpiNum; // The total number of SPI devices
-  localparam int unsigned FixedGpioNum  = 1; // Number of GPIO instances that don't pass through the pinmux
-  localparam int unsigned TotalGpioNum  = GPIO_NUM + FixedGpioNum; // The total number of GPIO instances
-  localparam int unsigned TAccessLatency = 0; // Cycles of read data latency.
+  localparam int unsigned MemSize         = 128 * 1024; // 128 KiB
+  localparam int unsigned SRAMAddrWidth   = $clog2(MemSize);
+  localparam int unsigned HyperRAMSize    = 8 * 1024 * 1024; // 8 MiB
+  localparam int unsigned HyperRAMTagSize = 8 * 1024 * 1024; // 8 MiB which can hold capabilities.
+  localparam int unsigned PwmCtrSize      = 8;
+  localparam int unsigned BusAddrWidth    = 32;
+  localparam int unsigned BusByteEnable   = 4;
+  localparam int unsigned BusDataWidth    = 32;
+  localparam int unsigned DRegAddrWidth   = 12; // Debug module uses 12 bits of addressing.
+  localparam int unsigned TRegAddrWidth   = 16; // Timer uses more address bits.
+  localparam int unsigned FixedSpiNum     = 2; // Number of SPI devices that don't pass through the pinmux
+  localparam int unsigned TotalSpiNum     = SPI_NUM + FixedSpiNum; // The total number of SPI devices
+  localparam int unsigned FixedGpioNum    = 1; // Number of GPIO instances that don't pass through the pinmux
+  localparam int unsigned TotalGpioNum    = GPIO_NUM + FixedGpioNum; // The total number of GPIO instances
+  localparam int unsigned TAccessLatency  = 0; // Cycles of read data latency.
 
   // The number of data bits controlled by each mask bit; since the CPU requires
   // only byte level access, explicitly grouping the data bits makes the inferred
@@ -521,6 +522,7 @@ module sonata_system
   hyperram #(
     .HyperRAMClkFreq ( HyperRAMClkFreq ),
     .HyperRAMSize    ( HyperRAMSize    ),
+    .HyperRAMTagSize ( HyperRAMTagSize ),
     .NumPorts        ( 2               )
   ) u_hyperram (
     .clk_i  (clk_sys_i),

--- a/sw/cheri/checks/hyperram_test.cc
+++ b/sw/cheri/checks/hyperram_test.cc
@@ -23,10 +23,52 @@
 
 #include "hyperram_memset.h"
 
+// Simulation is much slower than execution on FPGA and these tests are primarily intended for
+// FPGA-based testing. Define this to 1 for use in simulation.
+#define SIMULATION 0
+
 using namespace CHERI;
 
 const int RandTestBlockSize = 256;
-const int HyperramSize      = (1024 * 1024) / 4;
+#if SIMULATION
+// Note that this means many of the tests will be exercising only small fraction of the mapped
+// HyperRAM address range.
+const unsigned HyperramSize = HYPERRAM_BOUNDS / 1024;
+#else
+// Number of 32-bit words within the mapped HyperRAM.
+const unsigned HyperramSize = HYPERRAM_BOUNDS / 4;
+#endif
+
+// The amount of HyperRAM that supports capability stores.
+const unsigned HyperramTagSize = HYPERRAM_TAG_BOUNDS / 4;
+
+// Signals whether an exception should be trapped and the faulting instruction skipped.
+static volatile bool trap_err = false;
+
+// Records whether an attempt to store a capability to the HyperRAM resulted in a
+// TL-UL bus error and thus an exception.
+static volatile bool act_err = false;
+
+// TODO: #429 Presently the debugger cannot perform sub-word writes, so pad the BSS to 4 bytes.
+volatile uint16_t dummy;
+
+extern "C" void exception_handler(void) {
+  if (trap_err) {
+    // Record the fact that an exception occurred.
+    act_err = true;
+    // Advance over the failing instruction; this is a `csc` instruction but it may or may not be
+    // compressed.
+    __asm volatile(
+        "         cspecialr ct0, mepcc\n"
+        "         lh        t2, 0(ct0)\n"
+        "         li        t1, 3\n"
+        "         and       t2, t2, t1\n"
+        "         bne       t2, t1, instr16\n"
+        "         cincoffset ct0, ct0, 2\n"
+        "instr16: cincoffset ct0, ct0, 2\n"
+        "update:  cspecialw  mepcc, ct0");
+  }
+}
 
 // Ensure that all writing of code to memory has completed before commencing execution
 // of that code. Code has been written to [start, end] with both addresses being
@@ -129,10 +171,10 @@ int rand_cap_test(Capability<volatile uint32_t> hyperram_area,
     Capability<volatile uint32_t> read_cap;
 
     do {
-      rand_index = prng() % HyperramSize;
+      rand_index = prng() % HyperramTagSize;
 
       // Capability is double word in size.
-      rand_cap_index = prng() % (HyperramSize / 2);
+      rand_cap_index = prng() % (HyperramTagSize / 2);
     } while (rand_index / 2 == rand_cap_index);
 
     rand_val = prng();
@@ -670,6 +712,110 @@ int linear_execution_test(Capability<volatile uint32_t> hyperram_w_area, ds::xor
   return failures;
 }
 
+// Simple test of whether the full HyperRAM is mapped, as well checking that capabilities can
+// only be stored to the intended portion of this mapped range.
+int mapped_tagged_range_test(Capability<volatile uint32_t> hyperram_w_area,
+                             Capability<Capability<volatile uint32_t>> hyperram_cap_area, ds::xoroshiro::P64R32 &prng,
+                             Log &log, int iterations = 1) {
+  const bool verbose = false;
+  int failures       = 0;
+
+  // In the event that the entire HyperRAM supports capabilities, we must reduce two of our
+  // directed choices to be within bounds.
+  uint32_t tag_bounds_plus_8 = HYPERRAM_TAG_BOUNDS + 8;
+  uint32_t tag_bounds        = HYPERRAM_TAG_BOUNDS;
+  if (tag_bounds_plus_8 >= HYPERRAM_BOUNDS) {
+    tag_bounds_plus_8 = HYPERRAM_BOUNDS - 8;
+    tag_bounds        = HYPERRAM_BOUNDS - 16;
+  }
+
+  for (int iter = 0; iter < iterations; ++iter) {
+    Capability<volatile uint32_t> read_cap;
+    unsigned rand_choice = prng() & 7u;
+    uint32_t rand_addr;
+
+    switch (rand_choice) {
+      // Directed choices.
+      case 0u:
+        rand_addr = tag_bounds;
+        break;
+      case 1u:
+        rand_addr = HYPERRAM_TAG_BOUNDS - 8;
+        break;
+      case 2u:
+        rand_addr = HYPERRAM_BOUNDS - 8;
+        break;
+      case 3u:
+        rand_addr = tag_bounds_plus_8;
+        break;
+      case 4u:
+        rand_addr = 0u;
+        break;
+      // Randomised choices.
+      default:
+        rand_addr = prng() & (HYPERRAM_BOUNDS - 8u);
+        break;
+    }
+
+    // Predict whether we should see a TL-UL error in response; only the first portion of the
+    // mapped HyperRAM supports tag bits. Anything at a higher address should raise a TL-UL error.
+    bool exp_err = (rand_addr >= HYPERRAM_TAG_BOUNDS);
+    if (verbose) {
+      log.println("addr {:#x}", rand_addr);
+    }
+
+    // We are expecting to generate a TL-UL error with some store operations.
+    trap_err = true;
+    // First store some data that does not constitute a sensible capability.
+    const uint32_t exp_data1              = 0x87654321u;
+    const uint32_t exp_data0              = ~0u;
+    hyperram_w_area[rand_addr >> 2]       = exp_data0;
+    hyperram_w_area[(rand_addr >> 2) + 1] = exp_data1;
+
+    // Attempt to store a capability to the chosen address.
+    // The capability stored doesn't really matter; just use the HyperRAM base.
+    act_err                           = false;
+    hyperram_cap_area[rand_addr >> 3] = hyperram_w_area;
+    trap_err                          = false;
+    if (verbose) {
+      log.println("done write");
+    }
+    read_cap = hyperram_cap_area[rand_addr >> 3];
+
+    // Check that an error occurred iff expected.
+    failures += (act_err != exp_err);
+    if (verbose) {
+      log.println("Act err {}, exp err {}", (int)act_err, (int)exp_err);
+    }
+
+    // Check the memory contents.
+    if (exp_err) {
+      // If an error occurred then we expect _not_ to have performed the write, so the test data
+      // should still be intact.
+      uint32_t act_data1 = hyperram_w_area[(rand_addr >> 2) + 1];
+      uint32_t act_data0 = hyperram_w_area[rand_addr >> 2];
+      if (verbose) {
+        log.println("Wrote {:#x}:{:#x}, read back {:#x}:{:#x}", exp_data0, exp_data1, act_data0, act_data1);
+      }
+      if (exp_data0 != act_data0 || exp_data1 != act_data1) {
+        failures++;
+      }
+    } else {
+      // If there was no error, the capability should have been stored as expected.
+      if (verbose) {
+        volatile uint32_t *exp = hyperram_w_area.get();
+        volatile uint32_t *act = read_cap.get();
+        log.println("Wrote {:#x}, read back {:#x}", (uint32_t)exp, (uint32_t)act);
+      }
+      if (read_cap != hyperram_w_area) {
+        failures++;
+      }
+    }
+  }
+
+  return failures;
+}
+
 /**
  * C++ entry point for the loader.  This is called from assembly, with the
  * read-write root in the first argument.
@@ -695,23 +841,51 @@ extern "C" [[noreturn]] void entry_point(void *rwRoot) {
 
   // Default is word-based accesses, which is sufficient for most tests.
   Capability<volatile uint32_t> hyperram_area = root.cast<volatile uint32_t>();
-  hyperram_area.address()                     = HYPERRAM_ADDRESS;
-  hyperram_area.bounds()                      = HYPERRAM_BOUNDS;
+  uint32_t bounds                             = HYPERRAM_BOUNDS;
+  switch (3) {
+    // Courtesy of Leo.
+    case 0:
+      hyperram_area.address() = HYPERRAM_ADDRESS;
+      bounds                  = HYPERRAM_BOUNDS - 0x4000;
+      break;
+    // Cover only the tagged region.
+    case 1:
+      hyperram_area.address() = HYPERRAM_ADDRESS;
+      bounds                  = HYPERRAM_TAG_BOUNDS;
+      break;
+    // Cover just the untagged region.
+    case 2:
+      hyperram_area.address() = HYPERRAM_ADDRESS + HYPERRAM_TAG_BOUNDS;
+      bounds                  = HYPERRAM_BOUNDS - HYPERRAM_TAG_BOUNDS;
+      break;
+    // Map twice the valid region.
+    case 3:
+      hyperram_area.address() = HYPERRAM_ADDRESS;
+      bounds                  = 2 * HYPERRAM_BOUNDS;
+      break;
+    // This case does not work because the exponent becomes too large to
+    // be able to represent 8MiB range, and instead we end up with bounds of
+    // 16MiB and an invalid capability.
+    default:
+      hyperram_area.address() = HYPERRAM_ADDRESS;
+      bounds                  = HYPERRAM_TAG_BOUNDS;
+      break;
+  }
 
   Capability<Capability<volatile uint32_t>> hyperram_cap_area = root.cast<Capability<volatile uint32_t>>();
   hyperram_cap_area.address()                                 = HYPERRAM_ADDRESS;
-  hyperram_cap_area.bounds()                                  = HYPERRAM_BOUNDS;
+  hyperram_cap_area.bounds()                                  = bounds;
 
   // We also want byte, hword and dword access for some tests.
   Capability<volatile uint8_t> hyperram_b_area  = root.cast<volatile uint8_t>();
   hyperram_b_area.address()                     = HYPERRAM_ADDRESS;
-  hyperram_b_area.bounds()                      = HYPERRAM_BOUNDS;
+  hyperram_b_area.bounds()                      = bounds;
   Capability<volatile uint16_t> hyperram_h_area = root.cast<volatile uint16_t>();
   hyperram_h_area.address()                     = HYPERRAM_ADDRESS;
-  hyperram_h_area.bounds()                      = HYPERRAM_BOUNDS;
+  hyperram_h_area.bounds()                      = bounds;
   Capability<volatile uint64_t> hyperram_d_area = root.cast<volatile uint64_t>();
   hyperram_d_area.address()                     = HYPERRAM_ADDRESS;
-  hyperram_d_area.bounds()                      = HYPERRAM_BOUNDS;
+  hyperram_d_area.bounds()                      = bounds;
 
   // Run indefinitely, soak testing until we observe one or more failures.
   int failures = 0;
@@ -820,6 +994,10 @@ extern "C" [[noreturn]] void entry_point(void *rwRoot) {
                               (WriteTestType)test_type, 0x400u);
     }
     log.print("  result...");
+    write_test_result(log, failures);
+
+    log.println("Running mapped/tagged range test...");
+    failures += mapped_tagged_range_test(hyperram_area, hyperram_cap_area, prng, log, 0x400u);
     write_test_result(log, failures);
   }
 

--- a/sw/cheri/common/hyperram_exec_test.S
+++ b/sw/cheri/common/hyperram_exec_test.S
@@ -1,14 +1,21 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-.include "assembly-helpers.s"
+	.include "assembly-helpers.s"
 
 	.section .text, "ax", @progbits
 
 	.globl get_hyperram_fn_ptr
 	.p2align 2
-    .type get_hyperram_fn_ptr,@function
+	.type get_hyperram_fn_ptr,@function
+
+// Return an executable capability for the given address; this relies upon pcc containing the
+// supplied address already.
+//
+// entry a0 = address of function
+// return ca0 -> function
 get_hyperram_fn_ptr:
-  auipcc ct0, 0
-  csetaddr ca0, ct0, a0
-  cret
+	auipcc ct0, 0
+	csetaddr ca0, ct0, a0
+	cret
+

--- a/sw/cheri/common/hyperram_perf_test.S
+++ b/sw/cheri/common/hyperram_perf_test.S
@@ -31,7 +31,6 @@
 // ca0 -> destination (word-aligned)
 // ca1 -> source (word-aligned)
 // a2  =  number of bytes to copy
-// return -> beyond destination data.
 hyperram_copy_block:
   srl   a3, a2, 5
   andi  a2, a2, 31  // 0-31 bytes remaining after 32-byte loop.

--- a/sw/common/defs.h
+++ b/sw/common/defs.h
@@ -13,7 +13,9 @@
 #define SRAM_BOUNDS (0x0002'0000)
 
 #define HYPERRAM_ADDRESS (0x4000'0000)
-#define HYPERRAM_BOUNDS (0x0010'0000)
+#define HYPERRAM_BOUNDS (0x0080'0000)
+// The portion of the HyperRAM that can support capabilities.
+#define HYPERRAM_TAG_BOUNDS (0x0080'0000)
 
 #define SYSTEM_INFO_ADDRESS (0x8000'C000)
 #define SYSTEM_INFO_BOUNDS (0x0000'0020)


### PR DESCRIPTION
Modify the HyperRAM implementation such that it can support capabilities for part of the address range, but not necessarily the entire memory. It turns out that at present it is possible to provide tags for the entire 8MiB address range, albeit at a cost of leaving just 4 RAMB36 blocks for use elsewhere. These may be required for other HyperRAM changes (e.g. 200MHz operation), larger FIFOs or faster SPI controllers.

HyperRAM changes could necessitate use of 3 block RAMs for async FIFOs at the CDC.

@marnovandermaas We should be careful not to produce a release that offers more tagged memory than can be sustained in later revisions, please. Thoughts? This is the reason I've marked the PR as draft for now.