### PR TITLE
[DPI] Create .core file for i2cdpi to help reuse

### DIFF
--- a/dv/dpi/i2cdpi/i2cdpi.core
+++ b/dv/dpi/i2cdpi/i2cdpi.core
@@ -1,0 +1,31 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:sonata:i2cdpi"
+description: "I^2C DPI model"
+
+filesets:
+  files_rtl:
+    files:
+      - i2cdpi.sv: { file_type: systemVerilogSource }
+
+  files_c:
+    files:
+      - i2c_lsm9ds1.cc: { file_type: cppSource }
+      - i2c_lsm9ds1.hh: { file_type: cppSource, is_include_file: true }
+      - i2c_as621x.cc: { file_type: cppSource }
+      - i2c_as621x.hh: { file_type: cppSource, is_include_file: true }
+      - i2c_hat_id.cc: { file_type: cppSource }
+      - i2c_hat_id.hh: { file_type: cppSource, is_include_file: true }
+      - i2cdevice.cc: { file_type: cppSource }
+      - i2cdevice.hh: { file_type: cppSource, is_include_file: true }
+      - i2cdpi.cc: { file_type: cppSource }
+      - i2cdpi.hh: { file_type: cppSource, is_include_file: true }
+
+targets:
+  default:
+    filesets:
+      - files_rtl
+      - files_c
+

--- a/sonata.core
+++ b/sonata.core
@@ -32,20 +32,10 @@ filesets:
       - lowrisc:dv_dpi_sv:uartdpi:0.1
       - lowrisc:dv_dpi_c:usbdpi:0.1
       - lowrisc:dv_dpi_sv:usbdpi:0.1
+      - lowrisc:sonata:i2cdpi
       - lowrisc:sonata:spidevicedpi
     files:
       - rtl/system/rs485_ctrl.sv: { file_type: systemVerilogSource }
-      - dv/dpi/i2cdpi/i2c_lsm9ds1.cc: { file_type: cppSource }
-      - dv/dpi/i2cdpi/i2c_lsm9ds1.hh: { file_type: cppSource, is_include_file: true }
-      - dv/dpi/i2cdpi/i2c_as621x.cc: { file_type: cppSource }
-      - dv/dpi/i2cdpi/i2c_as621x.hh: { file_type: cppSource, is_include_file: true }
-      - dv/dpi/i2cdpi/i2c_hat_id.cc: { file_type: cppSource }
-      - dv/dpi/i2cdpi/i2c_hat_id.hh: { file_type: cppSource, is_include_file: true }
-      - dv/dpi/i2cdpi/i2cdevice.cc: { file_type: cppSource }
-      - dv/dpi/i2cdpi/i2cdevice.hh: { file_type: cppSource, is_include_file: true }
-      - dv/dpi/i2cdpi/i2cdpi.sv: { file_type: systemVerilogSource }
-      - dv/dpi/i2cdpi/i2cdpi.cc: { file_type: cppSource }
-      - dv/dpi/i2cdpi/i2cdpi.hh: { file_type: cppSource, is_include_file: true }
       - dv/models/hyperram/rtl/hyperram_W956.sv: { file_type: systemVerilogSource }
       - dv/models/fpga/rtl/DNA_PORT.v: { file_type: systemVerilogSource }
       - dv/models/fpga/rtl/IOBUF.v: { file_type: systemVerilogSource }


### PR DESCRIPTION
Having a .core file specifically for the I^2C DPI module makes it easier to use in other projects.