### PR TITLE
WaveDrom documentation fix + other doc updates

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -26,7 +26,7 @@ additional-css = [
 ]
 
 [preprocessor.wavejson]
-command = "./util/mdbook_wavejson.py"
+command = "python3 ./util/mdbook_wavejson.py"
 
 [preprocessor.replace]
 after = ["links"]

--- a/doc/ip/i2c.md
+++ b/doc/ip/i2c.md
@@ -1,13 +1,15 @@
 # Inter-integrated circuit (I2C) host
 
-For the I2C block in Sonata, we use the [OpenTitan IP](https://opentitan.org/book/hw/ip/i2c/index.html).
-We hardcode this block to be in host mode, so you can ignore the target functionality, including register `ovrd`, `val`, `target_id`, `acqdata` and `txdata`.
-Other than those you can find the [register definitions here](https://opentitan.org/book/hw/ip/i2c/doc/registers.html).
+For the I2C block in Sonata, we use the OpenTitan IP.
+The version of the IP that is vendored in has documentation that you can find [here](https://github.com/lowRISC/opentitan/tree/a78922f14a8cc20c7ee569f322a04626f2ac6127/hw/ip/i2c/doc).
+Another useful reference is the [existing driver](https://github.com/microsoft/cheriot-rtos/blob/main/sdk/include/platform/sunburst/platform-i2c.hh) for this block in the CHERIoT RTOS repository.
+We hardcode this block to be in host mode, so you can ignore the target functionality, including the following registers: `ovrd`, `val`, `target_id`, `acqdata` and `txdata`.
+Other than those, you can find the [register definitions here](https://github.com/lowRISC/opentitan/blob/a78922f14a8cc20c7ee569f322a04626f2ac6127/hw/ip/i2c/doc/registers.md).
 The registers `0x00` - `0x10` are also not accessible.
 The control register is just hardwired to be in host mode.
 
 For Sonata, we include two I2C blocks.
-The registers of the second I2C block can be accessed with and additional `0x1000` offset.
+The registers of the second I2C block can be accessed with an additional `0x1000` offset.
 These can be connected to any of these I2C targets:
 - Two for the QWIIC connectors.
 - One for the mikroBUS.

--- a/doc/ip/plic.md
+++ b/doc/ip/plic.md
@@ -7,33 +7,27 @@ Not all of these registers are mapped, most importantly we only have one core, s
 
 The following table shows the current list of interrupts that are fed through the PLIC.
 For more detailed descriptions of what each interrupt means, please refer to the documentation of each individual hardware IP block.
-More interrupts may be added to this table in the future.
+For most blocks, interrupts are multiplexed - all hardware interrupt sources are presented as a single interrupt to the PLIC.
+The relevant software `INTR_STATE` registers should be queried by software to determine the interrupt cause.
 
-| Number | Block     | Interrupt description |
-|--------|-----------|-----------------------|
-|  0     | None      | Tied to zero
-|  1,  9 | UART 0, 1 | Transmit watermark
-|  2, 10 | UART 0, 1 | Receive watermark
-|  3, 11 | UART 0, 1 | Transmit empty
-|  4, 12 | UART 0, 1 | Receive overflow
-|  5, 13 | UART 0, 1 | Receive frame error
-|  6, 14 | UART 0, 1 | Receive break error
-|  7, 15 | UART 0, 1 | Receive timeout
-|  8, 16 | UART 0, 1 | Receive parity error
-| 17, 32 | I2C 0, 1  | Format FIFO threshold
-| 18, 33 | I2C 0, 1  | Receive FIFO threshold
-| 19, 34 | I2C 0, 1  | Acquire FIFO threshold
-| 20, 35 | I2C 0, 1  | Receive FIFO overflow
-| 21, 36 | I2C 0, 1  | Received NACK
-| 22, 37 | I2C 0, 1  | SCL interference
-| 23, 38 | I2C 0, 1  | SDA interference
-| 24, 39 | I2C 0, 1  | Stretch timeout
-| 25, 40 | I2C 0, 1  | SDA unstable
-| 26, 41 | I2C 0, 1  | Command complete
-| 27, 42 | I2C 0, 1  | Transmit stretch
-| 28, 43 | I2C 0, 1  | Transmit threshold
-| 29, 44 | I2C 0, 1  | Acquire FIFO full
-| 30, 45 | I2C 0, 1  | Unexpected stop
-| 31, 46 | I2C 0, 1  | Host timeout
-| 47     | Ethernet  | Interrupt from external SPI ethernet chip (KSZ8851SNLI-TR). Check the interrupt status register for details.
-
+| Number | Block      | Interrupt description |
+|--------|------------|-----------------------|
+| 0      | None       | Tied to zero
+| 1      | Revoker    | Hardware revoker sweep complete
+| 2      | Ethernet   | Interrupt from external SPI ethernet chip (KSZ8851SNLI-TR)
+| 3      | USB Dev    | Shared USB Device interrupt
+| 4      | GPIO       | Shared GPIO interrupt
+| 5-7    | None       | Reserved
+| 8      | UART 0     | Shared interrupt for UART0
+| 9      | UART 1     | Shared interrupt for UART1
+| 10     | UART 2     | Shared interrupt for UART2
+| 11-15  | None       | Reserved
+| 16     | I2C 0      | Shared interrupt for I2C0
+| 17     | I2C 1      | Shared interrupt for I2C1
+| 18-23  | None       | Reserved
+| 24     | SPI LCD    | Shared interrupt for the LCD SPI
+| 25     | SPI Ethmac | Shared interrupt for the Ethernet SPI
+| 26     | SPI 0      | Shared interrupt for SPI0
+| 27     | SPI 1      | Shared interrupt for SPI1
+| 28     | SPI 2      | Shared interrupt for SPI2
+| 29-31  | None       | Reserved

--- a/doc/ip/spi.md
+++ b/doc/ip/spi.md
@@ -34,8 +34,6 @@ To begin an SPI transaction write to the [`START`](#start) register.
 Bytes do not need to be immediately available in the transmit FIFO nor space available in the receive FIFO to begin the transaction.
 The SPI block will only run the clock when its able to proceed.
 
-**Note Interrupts are not yet implemented**
-
 
 ## Register Table
 

--- a/doc/ip/uart.md
+++ b/doc/ip/uart.md
@@ -1,7 +1,8 @@
 # Universal asynchronous receiver/transmitter (UART)
 
-The Sonata system uses [the OpenTitan UART](https://opentitan.org/book/hw/ip/uart/index.html).
-You can find [the register definitions here](https://opentitan.org/book/hw/ip/uart/doc/registers.html).
+The Sonata system uses the OpenTitan UART.
+The version of the IP that is vendored in has documentation that you can find [here](https://github.com/lowRISC/opentitan/tree/a78922f14a8cc20c7ee569f322a04626f2ac6127/hw/ip/uart/doc).
+You can find [the register definitions here](https://github.com/lowRISC/opentitan/blob/a78922f14a8cc20c7ee569f322a04626f2ac6127/hw/ip/uart/doc/registers.md).
 
 There are multiple UART instances in Sonata to connect to any of the following targets:
 - USB

--- a/flake.nix
+++ b/flake.nix
@@ -84,6 +84,7 @@
       sonata-documentation = lrDoc.buildMdbookSite {
         version = "";
         pname = "sonata-documentation";
+        nativeBuildInputs = [pkgs.python311];
         src = fileset.toSource {
           root = ./.;
           fileset = fileset.unions [

--- a/util/mdbook/wavejson/wavejson.js
+++ b/util/mdbook/wavejson/wavejson.js
@@ -1,4 +1,11 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-window.addEventListener('load', WaveDrom.ProcessAll)
+
+// WaveDrom must run after mdBook has finished all DOM mutations. Using `window.load`
+// is unreliable because content might still be re-written at that time, causing
+// WaveDROM to see a partially mutated DOM and fail. It seems likely that newer
+// mdBook versions have somehow implemented heavier / longer DOM manipulation.
+document.addEventListener("DOMContentLoaded", () =>
+    requestAnimationFrame(() => WaveDrom.ProcessAll())
+);


### PR DESCRIPTION
Closes https://github.com/lowRISC/sonata-system/issues/423.
Closes https://github.com/lowRISC/sonata-system/issues/199.
Closes https://github.com/lowRISC/sonata-system/issues/146.

Mostly focused around fixing the existing WaveDrom issue. Also solves a couple of outstanding issues where linked documentation is not pinned to the correct revision, causing it to become out of date as the relevant vendored blocks are changed upstream. Maybe it would be better to just include the old OT docs in-place (like we do for SPI Host) now that WaveDrom is fixed, but for now this keeps the changes simple. Finally, updates the PLIC documentation since this was entirely out of date at this point.

Tested locally using:
```
nix build .#sonata-documentation
python -m http.server -d result
```